### PR TITLE
Fix dzo exporter failing when material doesn't have _Emission INTEGER

### DIFF
--- a/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
+++ b/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
@@ -1932,11 +1932,11 @@ public static class ForgeBuilder
 
         // export glb
         // export metadata on success
-        await MapExporter.ExportSceneForDZO(outGlbFile, outMetadataFile);
-
-        CopyToBuildFolders(EditorSceneManager.GetActiveScene());
-
-        Debug.Log("DZO build complete");
+        if (await MapExporter.ExportSceneForDZO(outGlbFile, outMetadataFile))
+        {
+            CopyToBuildFolders(EditorSceneManager.GetActiveScene());
+            Debug.Log("DZO build complete");
+        }
     }
 
     private static void WritePVarData(string outFilePath, byte[] pvars)

--- a/Assets/Forge/Scripts/Editor/Exporters/MapExporter.cs
+++ b/Assets/Forge/Scripts/Editor/Exporters/MapExporter.cs
@@ -1,5 +1,6 @@
 using GLTFast.Export;
 using Newtonsoft.Json;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -186,6 +187,11 @@ public static class MapExporter
 
             return true;
         }
+        catch (Exception ex)
+        {
+            Debug.LogException(ex);
+            return false;
+        }
         finally
         {
             // cleanup generators
@@ -237,6 +243,12 @@ public static class MapExporter
         // Go through all mesh filters and establish the mapping between the materials and all mesh filters using it.
         foreach (var meshFilter in meshFilters)
         {
+            // empty mesh
+            if (!meshFilter || !meshFilter.sharedMesh || meshFilter.sharedMesh.vertexCount <= 0)
+            {
+                continue;
+            }
+
             var meshRenderer = meshFilter.GetComponent<MeshRenderer>();
             if (meshRenderer == null)
             {
@@ -384,7 +396,7 @@ public static class MapExporter
             }
 
             // store emission
-            if (entry.Key.IsKeywordEnabled("_EMISSION") || entry.Key.GetInteger("_Emission") > 0)
+            if (entry.Key.IsKeywordEnabled("_EMISSION") || (entry.Key.HasInteger("_Emission") && entry.Key.GetInteger("_Emission") > 0))
             {
                 float intensity = entry.Key.GetColor("_EmissionColor").maxColorComponent;
                 newMat.EnableKeyword("_EMISSION");


### PR DESCRIPTION
Add exception logging to dzo exporter
Strip out empty meshes when building dzo glb