### PR TITLE
i/o bugfixes for UYA

### DIFF
--- a/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
+++ b/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
@@ -1468,8 +1468,30 @@ public static class ForgeBuilder
         }
 
         // clear moby instance dir
-        if (Directory.Exists(mobyInstancesFolder)) Directory.Delete(mobyInstancesFolder, true);
-        Directory.CreateDirectory(mobyInstancesFolder);
+		if (Directory.Exists(mobyInstancesFolder))
+		{
+			try
+			{
+				Directory.Delete(mobyInstancesFolder, true);
+			}
+			catch (IOException ex)
+			{
+				Debug.LogError($"Failed to delete mobyInstancesFolder: {mobyInstancesFolder}\nReason: {ex.Message}");
+				EditorUtility.DisplayDialog("File Lock Error", 
+					$"Could not delete mobyInstancesFolder.\nSome files may be in use.\n\n{ex.Message}", "OK");
+				return;
+			}
+			catch (UnauthorizedAccessException ex)
+			{
+				Debug.LogError($"Access denied while deleting mobyInstancesFolder: {mobyInstancesFolder}\nReason: {ex.Message}");
+				EditorUtility.DisplayDialog("Permission Error", 
+					$"Access denied when trying to delete mobyInstancesFolder.\n\n{ex.Message}", "OK");
+				return;
+			}
+		}
+
+		Directory.CreateDirectory(mobyInstancesFolder);
+
 
         // build mobys
         int i = 0;

--- a/Assets/Forge/Scripts/Editor/Importers/LevelImporterWindow.cs
+++ b/Assets/Forge/Scripts/Editor/Importers/LevelImporterWindow.cs
@@ -1226,6 +1226,10 @@ public class LevelImporterWindow : EditorWindow
         var unpackSounds = importMobys > 0;
         var unpackAssets = importMobys > 0 || importSky > 0 || importCollision > 0 || importTfrags > 0 || importTies > 0 || importShrubs > 0;
         var unpackGameplay = importMobys > 0 || importWorldConfig > 0 || importMisc > 0;
+        if (racVersion == RCVER.UYA)
+        {
+            unpackGameplay = importMobys > 0 || importWorldConfig > 0 || importMisc > 0 || importTies > 0 || importShrubs > 0;
+        }
         var unpackOcclusion = importTies > 0 || importTfrags > 0 || importMobys > 0;
         var unpackWorldInstances = importTies > 0 || importShrubs > 0 || importWorldConfig > 0 || unpackOcclusion;
         var unpackCollision = importCollision > 0;

--- a/pvar_overlay.json
+++ b/pvar_overlay.json
@@ -3293,7 +3293,7 @@
     "MobyOClass": 6889,
     "Length": 32,
     "Default": "FFFFFFFF00000000000000000000000000000000000000000000000000000000",
-    "Pointers": "8,0",
+    "Pointers": "",
     "Overlay": [
       {
         "Name": "Parent Node",


### PR DESCRIPTION
- Add error dialog and abort export if existing Moby instance is locked for editing, rather than failing silently 
- Remove pvar-ptr from sloped Korg bridge
- Unpack gameplay instances if importing Ties or Shrubs but not Mobys