### PR TITLE
Add author, description, and thumbnail fields

### DIFF
--- a/Assets/Forge/Scripts/Configuration/DzoConfig.cs
+++ b/Assets/Forge/Scripts/Configuration/DzoConfig.cs
@@ -7,6 +7,8 @@ public class DzoConfig : MonoBehaviour
 {
     [Header("World Settings")]
     public Transform DefaultCameraPosition;
+    public bool UseBackgroundColorOverride = false;
+    [ColorUsage(false)] public Color BackgroundColorOverride = Color.white;
 
     [Header("Export Static Geometry")]
     public bool Ties = true;

--- a/Assets/Forge/Scripts/Configuration/MapConfig.cs
+++ b/Assets/Forge/Scripts/Configuration/MapConfig.cs
@@ -18,7 +18,7 @@ public class MapConfig : MonoBehaviour
     [Min(0)] public int MapVersion = 0;
     public string MapName;
     public string MapAuthor;
-    public string MapDescription;
+    [Multiline] public string MapDescription;
     public string MapFilename;
 
     [Header("Deadlocked")]

--- a/Assets/Forge/Scripts/Configuration/MapConfig.cs
+++ b/Assets/Forge/Scripts/Configuration/MapConfig.cs
@@ -24,13 +24,15 @@ public class MapConfig : MonoBehaviour
     [Header("Deadlocked")]
     [ReadOnly] public DLMapIds DLBaseMap = DLMapIds.SP_Battledome;
     public DLCustomModeIds DLForceCustomMode = DLCustomModeIds.None;
-    public Texture2D DLLoadingScreen;
+    [Tooltip("Aspect ratio 1:1")] public Texture2D DLLoadingScreen;
+    [Tooltip("Aspect ratio 2:1")] public Texture2D DLThumbnail;
     public Texture2D DLMinimap;
     public int[] DLMobysIncludedInExport;
 
     [Header("UYA")]
     [ReadOnly] public UYAMapIds UYABaseMap = UYAMapIds.SP_Veldin;
     public Texture2D UYAMinimap;
+    [Tooltip("Aspect ratio 2:1")] public Texture2D UYAThumbnail;
     public int[] UYAMobysIncludedInExport;
 
     [Header("Render Settings")]

--- a/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
+++ b/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
@@ -349,6 +349,7 @@ public static class ForgeBuilder
         var worldPath = ctx.RacVersion == RCVER.DL ? null : Path.Combine(binFolder, FolderNames.GetWorldWadFilename(baseMap, ctx.RacVersion));
         var soundPath = Path.Combine(binFolder, FolderNames.GetSoundWadFilename(baseMap, ctx.RacVersion));
         var bgPngPath = AssetDatabase.GetAssetPath(mapConfig.DLLoadingScreen);
+        var thumbPngPath = ctx.RacVersion == RCVER.DL ? AssetDatabase.GetAssetPath(mapConfig.DLThumbnail) : AssetDatabase.GetAssetPath(mapConfig.UYAThumbnail);
         var minimapPngPath = ctx.RacVersion == RCVER.DL ? AssetDatabase.GetAssetPath(mapConfig.DLMinimap) : AssetDatabase.GetAssetPath(mapConfig.UYAMinimap);
         var customModeDatas = GameObject.FindObjectsOfType<CustomModeData>()?.Where(x => x.IsEnabled)?.ToArray();
 
@@ -473,6 +474,28 @@ public static class ForgeBuilder
                     Debug.LogError($"Failed to pack loading screen. {result}");
                     return;
                 }
+            }
+        }
+
+        // build thumbnail
+        if (File.Exists(thumbPngPath))
+        {
+            var tempPngPath = Path.Combine(FolderNames.GetTempFolder(), $"{mapConfig.MapFilename}.png");
+            var thumb = AssetDatabase.LoadAssetAtPath<Texture2D>(thumbPngPath);
+            var outPif2File = Path.Combine(buildPath, $"{mapConfig.MapFilename}.pif2");
+            if (thumb)
+            {
+                UnityHelper.SaveTexture(UnityHelper.ResizeTexture(thumb, 128, 64), tempPngPath, Color.white, hasAlpha: true);
+                var result = PackerHelper.ConvertPngToPif8bpp(tempPngPath, buildPath, half_alpha: true, outSwizzle: false);
+                if (result != PackerHelper.PACKER_STATUS_CODES.SUCCESS)
+                {
+                    Debug.LogError($"Failed to pack thumbnail. {result}");
+                    return;
+                }
+
+                var outThumbFile = Path.Combine(buildPath, $"{mapConfig.MapFilename}{regionExt}.thumb");
+                if (File.Exists(outThumbFile)) File.Delete(outThumbFile);
+                if (File.Exists(outPif2File)) File.Move(outPif2File, outThumbFile);
             }
         }
     }

--- a/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
+++ b/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
@@ -329,7 +329,7 @@ public static class ForgeBuilder
             if (!Directory.Exists(mapBuildFolder)) continue;
             if (buildFolders == null) continue;
 
-            foreach (var buildFolder in settings.DLBuildFolders)
+            foreach (var buildFolder in buildFolders)
             {
                 if (Directory.Exists(buildFolder))
                 {

--- a/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
+++ b/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
@@ -379,7 +379,7 @@ public static class ForgeBuilder
                     writer.Write((short)mapConfig.ShrubMinRenderDistance); // shrub min render distance
                     writer.WriteString(mapConfig.MapName, 32);
                     writer.WriteString(mapConfig.MapAuthor, 32);
-                    writer.WriteString(mapConfig.MapDescription, 256);
+                    writer.WriteString(BinaryHelper.StrToRatchetStr(mapConfig.MapDescription), 256);
                 }
                 else
                 {
@@ -389,7 +389,7 @@ public static class ForgeBuilder
                     writer.Write((int)0); // padding
                     writer.WriteString(mapConfig.MapName, 32);
                     writer.WriteString(mapConfig.MapAuthor, 32);
-                    writer.WriteString(mapConfig.MapDescription, 256);
+                    writer.WriteString(BinaryHelper.StrToRatchetStr(mapConfig.MapDescription), 256);
                 }
 
                 // write extra data (DL only)

--- a/Assets/Forge/Scripts/Editor/Configuration/MapConfigEditor.cs
+++ b/Assets/Forge/Scripts/Editor/Configuration/MapConfigEditor.cs
@@ -22,10 +22,12 @@ public class MapConfigEditor : Editor
     SerializedProperty m_DLBaseMap;
     SerializedProperty m_DLForceCustomMode;
     SerializedProperty m_DLLoadingScreen;
+    SerializedProperty m_DLThumbnail;
     SerializedProperty m_DLMinimap;
     SerializedProperty m_DLMobysIncludedInExport;
 
     SerializedProperty m_UYABaseMap;
+    SerializedProperty m_UYAThumbnail;
     SerializedProperty m_UYAMinimap;
     SerializedProperty m_UYAMobysIncludedInExport;
 
@@ -52,10 +54,12 @@ public class MapConfigEditor : Editor
         m_DLBaseMap = serializedObject.FindProperty("DLBaseMap");
         m_DLForceCustomMode = serializedObject.FindProperty("DLForceCustomMode");
         m_DLLoadingScreen = serializedObject.FindProperty("DLLoadingScreen");
+        m_DLThumbnail = serializedObject.FindProperty("DLThumbnail");
         m_DLMinimap = serializedObject.FindProperty("DLMinimap");
         m_DLMobysIncludedInExport = serializedObject.FindProperty("DLMobysIncludedInExport");
 
         m_UYABaseMap = serializedObject.FindProperty("UYABaseMap");
+        m_UYAThumbnail = serializedObject.FindProperty("UYAThumbnail");
         m_UYAMinimap = serializedObject.FindProperty("UYAMinimap");
         m_UYAMobysIncludedInExport = serializedObject.FindProperty("UYAMobysIncludedInExport");
 
@@ -93,6 +97,7 @@ public class MapConfigEditor : Editor
         {
             EditorGUILayout.PropertyField(m_DLForceCustomMode);
             EditorGUILayout.PropertyField(m_DLLoadingScreen);
+            EditorGUILayout.PropertyField(m_DLThumbnail);
             EditorGUILayout.PropertyField(m_DLMinimap);
             EditorGUILayout.PropertyField(m_DLMobysIncludedInExport);
         }
@@ -109,6 +114,7 @@ public class MapConfigEditor : Editor
         EditorGUILayout.PropertyField(m_UYABaseMap);
         if ((target as MapConfig).HasUYABaseMap())
         {
+            EditorGUILayout.PropertyField(m_UYAThumbnail);
             EditorGUILayout.PropertyField(m_UYAMinimap);
             EditorGUILayout.PropertyField(m_UYAMobysIncludedInExport);
         }

--- a/Assets/Forge/Scripts/Editor/Exporters/MapExporter.cs
+++ b/Assets/Forge/Scripts/Editor/Exporters/MapExporter.cs
@@ -94,7 +94,7 @@ public static class MapExporter
             {
                 SkymeshName = sky ? objectPathPrefix + sky.gameObject.name : null,
                 MinimapMeshName = minimapGo ? objectPathPrefix + minimapGo.name : null,
-                BackgroundColor = mapConfig.BackgroundColor,
+                BackgroundColor = dzoConfig.UseBackgroundColorOverride ? dzoConfig.BackgroundColorOverride : mapConfig.BackgroundColor,
                 FogColor = dzoConfig.FogOverride ? dzoConfig.FogOverrideColor : mapConfig.FogColor,
                 FogNearDistance = dzoConfig.FogOverride ? dzoConfig.FogOverrideNearDistance : fogNear,
                 FogFarDistance = dzoConfig.FogOverride ? dzoConfig.FogOverrideFarDistance : fogFar,


### PR DESCRIPTION
Adds fields for map author, description, and thumbnail to map config.
Adds dzo background override option to dzo config (fixed #65)
Fixes copy to build folders not working for uya

<img width="530" height="325" alt="image" src="https://github.com/user-attachments/assets/10274b0b-f8f5-48a3-97de-837cca9b7095" />

<img width="671" height="545" alt="f3b99928-74a0-4f6b-8bd2-32ed0f8c0489" src="https://github.com/user-attachments/assets/2817642a-f356-4bd5-b8d1-6fde6cef8f62" />


