### PR TITLE
Survival Updates

### DIFF
--- a/Assets/Forge/Scripts/CustomMode/SurvivalModeData.cs
+++ b/Assets/Forge/Scripts/CustomMode/SurvivalModeData.cs
@@ -86,6 +86,7 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
     [HideInInspector] public bool DebugInfiniteAmmo;
     [HideInInspector] public bool DebugPayday;
     [HideInInspector] public bool DebugMoonjump;
+    [HideInInspector] public int DebugStartRound;
 
     public List<SurvivalMobSpawnParam> GetEnabledMobs() => Mobs.Where(x => !x.Disabled).OrderBy(x => x.Probability).ThenBy(x => Mobs.IndexOf(x)).ToList();
 
@@ -194,6 +195,7 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
             if (DebugInfiniteAmmo) state.LDFlags.Add("-DDEBUG_INFINITE_AMMO");
             if (DebugPayday) state.LDFlags.Add("-DDEBUG_PAYDAY");
             if (DebugMoonjump) state.LDFlags.Add("-DDEBUG_MOONJUMP");
+            if (DebugStartRound > 0) state.LDFlags.Add($"-DDEBUG_START_ROUND={DebugStartRound}");
         }
 
         state.Includes.Add("#include \"game.h\"");

--- a/Assets/Forge/Scripts/Editor/CustomMode/SurvivalModeDataEditor.cs
+++ b/Assets/Forge/Scripts/Editor/CustomMode/SurvivalModeDataEditor.cs
@@ -20,6 +20,7 @@ public class SurvivalModeDataEditor : Editor
     private SerializedProperty m_DebugInfiniteAmmoProperty;
     private SerializedProperty m_DebugPaydayProperty;
     private SerializedProperty m_DebugMoonjumpProperty;
+    private SerializedProperty m_DebugStartRoundProperty;
     
     private void OnEnable()
     {
@@ -31,6 +32,7 @@ public class SurvivalModeDataEditor : Editor
         m_DebugInfiniteAmmoProperty = serializedObject.FindProperty("DebugInfiniteAmmo");
         m_DebugPaydayProperty = serializedObject.FindProperty("DebugPayday");
         m_DebugMoonjumpProperty = serializedObject.FindProperty("DebugMoonjump");
+        m_DebugStartRoundProperty = serializedObject.FindProperty("DebugStartRound");
     }
 
     public override void OnInspectorGUI()
@@ -53,6 +55,7 @@ public class SurvivalModeDataEditor : Editor
             EditorGUILayout.PropertyField(m_DebugInfiniteAmmoProperty, new GUIContent("Infinite Ammo"));
             EditorGUILayout.PropertyField(m_DebugPaydayProperty, new GUIContent("Max Money/Tokens"));
             EditorGUILayout.PropertyField(m_DebugMoonjumpProperty, new GUIContent("Moonjump"));
+            EditorGUILayout.PropertyField(m_DebugStartRoundProperty, new GUIContent("Start at Round"));
             EditorGUILayout.PropertyField(m_DebugManualSpawningProperty, new GUIContent("Manual Mob Spawning"));
             if (m_DebugManualSpawningProperty.boolValue)
             {

--- a/codegen/rc4/survival/pool.c
+++ b/codegen/rc4/survival/pool.c
@@ -108,14 +108,16 @@ Moby* poolSpawn(int oclass, int pvarSize)
 #endif
 
     void* pvar = moby->PVar;
+    int deathCount = moby->Xp;
     ((void (*)(Moby*, int, int))0x004f7330)(moby, oclass, 1); // init moby instance
+    moby->Xp = (deathCount + 1) % 128; // indicate pool moby respawned
     if (pvar) {
       memset(pvar, 0, pvarSize);
       moby->PVar = pvar;
     }
   }
 
-  moby->Pad = poolIdx;
+  moby->Pad = 0x80 | poolIdx;
   group->PoolIndex = (poolIdx + 1) % group->PoolSize;
   return moby;
 }
@@ -129,7 +131,7 @@ void poolDestroy(Moby* moby)
     return;
   }
   
-  int poolIdx = moby->Pad;
+  int poolIdx = (u8)moby->Pad & ~0x80;
   if (poolIdx >= 0 && poolIdx < group->PoolSize && poolGetMoby(group, poolIdx) == moby) {
     moby->ModeBits |= MOBY_MODE_BIT_NO_POST_UPDATE | MOBY_MODE_BIT_DISABLED | MOBY_MODE_BIT_NO_UPDATE;
     moby->CollActive = -1;

--- a/codegen/rc4/survival/stackbox.c
+++ b/codegen/rc4/survival/stackbox.c
@@ -365,7 +365,7 @@ void sboxUpdate(Moby* moby)
     } else {
 
       int cost = sboxGetStackableCost(player->PlayerId, pvars->Item);
-      snprintf(buf, sizeof(buf), "\x11 %s\x01\x0E%'d\x08", STACKABLE_ITEM_NAMES[pvars->Item], cost);
+      snprintf(buf, sizeof(buf), "\x11 %s \x01\x0E%'d\x08", STACKABLE_ITEM_NAMES[pvars->Item], cost);
       if (tryPlayerInteract(moby, player, buf, STACKABLE_ITEM_DESC[pvars->Item], 0, 0, PLAYER_STACK_BOX_COOLDOWN_TICKS, STACK_BOX_MAX_DIST*STACK_BOX_MAX_DIST, PAD_CIRCLE)) {
         sboxPlayerBuy(moby, player->PlayerId, pvars->Item);
       }

--- a/codegen/rc4/survival/survival.c
+++ b/codegen/rc4/survival/survival.c
@@ -465,11 +465,31 @@ void survivalDebugInfiniteAmmo(void)
 //--------------------------------------------------------------------------
 void survivalDebugPayday(void)
 {
+  int i;
   static int init = 0;
   if (!MapConfig.State) return;
+  
+  // give max alpha mods
+  for (i = 0; i < GAME_MAX_LOCALS; ++i) {
+    Player* player = playerGetFromSlot(i);
+    if (!playerIsValid(player)) continue;
+
+    GadgetBox* gbox = player->GadgetBox;
+    if (!gbox) continue;
+  
+    gbox->ModBasic[0] = 64;
+    gbox->ModBasic[1] = 64;
+    gbox->ModBasic[2] = 64;
+    gbox->ModBasic[3] = 64;
+    gbox->ModBasic[4] = 64;
+    gbox->ModBasic[5] = 64;
+    gbox->ModBasic[6] = 64;
+    gbox->ModBasic[7] = 64;
+  }
+
   if (init) return;
 
-  int i;
+  // set bolts/tokens once
   for (i = 0; i < GAME_MAX_PLAYERS; ++i) {
     MapConfig.State->PlayerStates[i].State.Bolts = 100000000;
     MapConfig.State->PlayerStates[i].State.CurrentTokens = 10000;

--- a/codegen/rc4/survival/survival.c
+++ b/codegen/rc4/survival/survival.c
@@ -512,6 +512,51 @@ void survivalDebugMoonjump(void)
 }
 
 //--------------------------------------------------------------------------
+void survivalDebugStartRound(int roundNumber)
+{
+  struct SurvivalState* state = MapConfig.State;
+  if (!state) return;
+  if (roundNumber <= 1) return; // no round skip
+
+  static int init = 0;
+  if (init == 2) return;
+  if (init == 1) {
+      
+    // set round to immediately end after it is initialized by the game mode
+    if (state->RoundMaxMobCount) {
+      state->MobStats.TotalSpawnedThisRound = state->RoundMaxMobCount;
+      init = 2;
+    }
+
+    return;
+  }
+
+  // set to round prior to target round number
+  // once the game initializes the round we'll force it to end
+  // starting the target round (with the interum period)
+  state->RoundNumber = roundNumber - 2;
+  state->RoundMaxMobCount = 0;
+
+  // set initial bolt/token
+  // also bump health upgrades up a bit for testing convenience
+  int j;
+  for (j = 0; j < GAME_MAX_PLAYERS; ++j) {
+    state->PlayerStates[j].State.Bolts = powf(1.225, roundNumber) * 10000;
+    state->PlayerStates[j].State.CurrentTokens = roundNumber * 5;
+    state->PlayerStates[j].State.Upgrades[UPGRADE_HEALTH] = roundNumber;
+  }
+
+  // iterate each round
+  int i;
+  for (i = 0; i < state->RoundNumber; ++i) {
+    state->MobStats.TotalSpawned += MAX_MOBS_BASE + (int)(MAX_MOBS_ROUND_WEIGHT * (1 + i));
+  }
+
+  DPRINTF("Skipped to Round #%d with %d mobs spawned\n", state->RoundNumber + 1, state->MobStats.TotalSpawned);
+  init = 1;
+}
+
+//--------------------------------------------------------------------------
 void survivalInit(void)
 {
   static int initialized = 0;
@@ -636,6 +681,10 @@ int survivalTick(void)
     }
 #endif
   }
+
+#if DEBUG_START_ROUND
+  survivalDebugStartRound(DEBUG_START_ROUND);
+#endif
 
 #if DEBUG_MANUAL_SPAWNING
   survivalDebugManualSpawn();


### PR DESCRIPTION
- Improve pooled moby detection for DZO
- Include alpha mods in max bolts/token debug toggle
- Fix stackbox vendor missing space between perk name and price
- Add debug option to skip to a target round on load