### PR TITLE
Survival: Add ammo supply vendor, ammo drop mechanic, and mob targeting overrides

### DIFF
--- a/Assets/Forge/Prefabs/Survival/Survival Mob Config.asset
+++ b/Assets/Forge/Prefabs/Survival/Survival Mob Config.asset
@@ -94,7 +94,7 @@ MonoBehaviour:
     HealthMax: 100000000
     HealthScale: 1
     TurnSpeed: 1
-    AttackRadius: 5
+    AttackRadius: 4
     RangedAttackDistance: 50
     HitRadius: 0.5
     CollRadius: 1
@@ -158,7 +158,7 @@ MonoBehaviour:
     HealthMax: 50000000
     HealthScale: 1
     TurnSpeed: 1
-    AttackRadius: 5
+    AttackRadius: 4
     RangedAttackDistance: 50
     HitRadius: 1.75
     CollRadius: 0.5
@@ -198,7 +198,7 @@ MonoBehaviour:
     HealthMax: 50000000
     HealthScale: 1
     TurnSpeed: 1
-    AttackRadius: 5
+    AttackRadius: 4
     RangedAttackDistance: 50
     HitRadius: 2
     CollRadius: 1
@@ -252,7 +252,7 @@ MonoBehaviour:
     HealthMax: 100000000
     HealthScale: 1.1
     TurnSpeed: 1
-    AttackRadius: 3.5
+    AttackRadius: 3
     RangedAttackDistance: 50
     HitRadius: 0.5
     CollRadius: 2
@@ -294,7 +294,7 @@ MonoBehaviour:
     HealthMax: 200000000
     HealthScale: 1
     TurnSpeed: 1
-    AttackRadius: 7
+    AttackRadius: 6
     RangedAttackDistance: 50
     HitRadius: 1.5
     CollRadius: 2
@@ -334,7 +334,7 @@ MonoBehaviour:
     HealthMax: 100000000
     HealthScale: 1
     TurnSpeed: 1
-    AttackRadius: 5
+    AttackRadius: 4
     RangedAttackDistance: 50
     HitRadius: 1
     CollRadius: 1
@@ -374,7 +374,7 @@ MonoBehaviour:
     HealthMax: 100000000
     HealthScale: 1
     TurnSpeed: 1
-    AttackRadius: 5
+    AttackRadius: 4
     RangedAttackDistance: 50
     HitRadius: 1
     CollRadius: 1
@@ -414,7 +414,7 @@ MonoBehaviour:
     HealthMax: 1e+9
     HealthScale: 1.05
     TurnSpeed: 1
-    AttackRadius: 5
+    AttackRadius: 4
     RangedAttackDistance: 50
     HitRadius: 2
     CollRadius: 1.5

--- a/Assets/Forge/Scripts/CustomMode/SurvivalModeData.cs
+++ b/Assets/Forge/Scripts/CustomMode/SurvivalModeData.cs
@@ -11,7 +11,7 @@ using UnityEngine.SceneManagement;
 
 public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
 {
-    public static readonly int SURVIVAL_VERSION = 6;
+    public static readonly int SURVIVAL_VERSION = 7;
     public const int DEMONBELL_OCLASS = 0x2479;
     public const int BANK_OCLASS = 0x1F7;
     public const int STACKBOX_OCLASS = 0x2083;

--- a/Assets/Forge/Scripts/CustomMode/SurvivalModeData.cs
+++ b/Assets/Forge/Scripts/CustomMode/SurvivalModeData.cs
@@ -34,6 +34,7 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
     [Min(0), Tooltip("Lower values will increase weapon pickup respawn frequency.")] public float WeaponPickupCooldownFactor = 1;
     public bool HidePrestigeMachineEvery25Rounds = true;
     public bool RandomizeWeaponPickupsAtStart = true;
+    [Range(0f, 1f)] public float AmmoDropProbability = 0;
 
     [Header("Mobs"), Tooltip("Your map's customized mob list. Max of 10.")]
     public List<SurvivalMobSpawnParam> Mobs = new List<SurvivalMobSpawnParam>()
@@ -149,8 +150,10 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/path.o");
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/gambits.o");
 
+        state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/ammodrop.o");
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/upgrade.o");
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/drop.o");
+        state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/ammosupply.o");
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/pool.o");
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/demonbell.o");
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/bankbox.o");
@@ -180,6 +183,7 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
         state.LDFlags.Add("-DSURVIVAL");
         state.LDFlags.Add("-DGAMBITS");
         state.LDFlags.Add($"-DMAP_BASE_COMPLEXITY={MapBaseComplexity}");
+        state.LDFlags.Add($"-DAMMO_DROP_PROBABILITY={AmmoDropProbability}");
         var mobTypes = enabledMobs.Select(x => x.Mob).Distinct();
         foreach (var mobType in mobTypes)
             state.LDFlags.Add($"-DMOB_{mobType.ToString().ToUpper()}");

--- a/codegen/rc4/common/dummy.c
+++ b/codegen/rc4/common/dummy.c
@@ -36,6 +36,10 @@
 #include "dummy.h"
 #include "common.h"
 
+#if SURVIVAL || RAIDS
+#include "mob.h"
+#endif
+
 #if DEBUG
 #define DLOG(moby, format, ...) if (((struct DummyPVar*)moby->PVar)->Config.Log) { DPRINTF("uid:%d " format, (moby)->UID, ##__VA_ARGS__); }
 #else
@@ -103,6 +107,10 @@ void dummyOnStateChanged(Moby* moby)
           // explode
           if (pvars->Config.OnDeathType >= DUMMY_ON_DEATH_EXPLODE && difficultyConfig->ExplosionRadius > 0) {
             spawnExplosionDamage(targetMoby->Position, difficultyConfig->ExplosionRadius, 0x80004080, moby, difficultyConfig->ExplosionDamage, 0x00081801);
+            DPRINTF("damage %f\n", difficultyConfig->ExplosionDamage);
+#if SURVIVAL
+            mobReactToExplosionAt(moby, targetMoby->Position, difficultyConfig->ExplosionDamage, difficultyConfig->ExplosionRadius, 0);
+#endif
           }
 
           // blow corn
@@ -225,7 +233,7 @@ void dummyUpdate(Moby* moby)
   }
 
   // register target if friendly and targetable
-#if RAIDS
+#if RAIDS || SURVIVAL
   if (!pvars->Config.IsOnEnemyTeam && pvars->Config.MobTargetType != DUMMY_MOB_AGGRO_IGNORE) {
     mobRegisterTarget(moby);
   }

--- a/codegen/rc4/survival/ammodrop.c
+++ b/codegen/rc4/survival/ammodrop.c
@@ -1,0 +1,138 @@
+/***************************************************
+ * FILENAME :		ammodrop.c
+ * 
+ * DESCRIPTION :
+ * 		Handles logic for the ammo drops.
+ * 		
+ * AUTHOR :			Daniel "Dnawrkshp" Gerendasy
+ */
+
+#include <tamtypes.h>
+
+#include <libdl/dl.h>
+#include <libdl/player.h>
+#include <libdl/pad.h>
+#include <libdl/time.h>
+#include <libdl/net.h>
+#include <libdl/game.h>
+#include <libdl/string.h>
+#include <libdl/math.h>
+#include <libdl/math3d.h>
+#include <libdl/stdio.h>
+#include <libdl/gamesettings.h>
+#include <libdl/dialog.h>
+#include <libdl/sound.h>
+#include <libdl/patch.h>
+#include <libdl/ui.h>
+#include <libdl/moby.h>
+#include <libdl/graphics.h>
+#include <libdl/color.h>
+#include <libdl/utils.h>
+#include <libdl/collision.h>
+#include <libdl/random.h>
+#include "maputils.h"
+#include "shared.h"
+#include "ammodrop.h"
+#include "game.h"
+
+Moby* ammoDropMobyList[MAX_MOB_AMMO_DROPS];
+int ammoDropMobyListRollingIndex = 0;
+
+//--------------------------------------------------------------------------
+Player* ammodropFindPlayerFromGadgetBox(GadgetBox* gbox)
+{
+  Player** players = playerGetAll();
+
+  int i;
+  for (i = 0; i < GAME_MAX_PLAYERS; ++i) {
+    Player* player = players[i];
+    if (!playerIsValid(player)) continue;
+
+    if (player->GadgetBox == gbox) return player;
+  }
+}
+
+//--------------------------------------------------------------------------
+int ammodropTargetGetGadgetMaxAmmo(GadgetBox* gbox, int gadgetId)
+{
+  Player* player = ammodropFindPlayerFromGadgetBox(gbox);
+  if (!playerIsValid(player)) return 0;
+  if (!player->IsLocal) return 0; // local only
+
+  return playerGetWeaponMaxAmmo(gbox, gadgetId);
+}
+
+//--------------------------------------------------------------------------
+void ammodropUpdate(Moby* moby)
+{
+  // configure it to be pickup-able
+  if (moby->PVar) {
+    *(char*)(moby->PVar + 0x5C) = 1; // state
+  }
+
+  ((void (*)(Moby*))0x003ac050)(moby);
+}
+
+//--------------------------------------------------------------------------
+void ammodropCreateAt(Moby* moby)
+{
+  // find free slot
+  int i;
+  for (i = 0; i < MAX_MOB_AMMO_DROPS; ++i) {
+    if (!ammoDropMobyList[i] || mobyIsDestroyed(ammoDropMobyList[i]) || ammoDropMobyList[i]->OClass != MOBY_ID_AMMO) break;
+  }
+
+  // use rolling index
+  if (i >= MAX_MOB_AMMO_DROPS) {
+    i = ammoDropMobyListRollingIndex;
+  }
+
+  // destroy old ammo drop
+  if (ammoDropMobyList[i] && ammoDropMobyList[i]->OClass == MOBY_ID_AMMO) {
+    mobyDestroy(ammoDropMobyList[i]);
+  }
+
+  ammoDropMobyListRollingIndex = (i + 1) % MAX_MOB_AMMO_DROPS;
+  Moby* ammoMoby = ammoDropMobyList[i] = mobySpawn(MOBY_ID_AMMO, 0x100);
+  if (ammoMoby) {
+    
+    // snap to ground
+    VECTOR from = {0,0,1,0};
+    VECTOR to = {0,0,-10,0};
+    vector_copy(ammoMoby->Position, moby->Position);
+    vector_add(from, moby->Position, from);
+    vector_add(to, moby->Position, to);
+    if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+      vector_copy(ammoMoby->Position, CollLine_Fix_GetHitPosition());
+    }
+
+    // update draw
+    ammoMoby->Bangles |= 1;
+    ammoMoby->DrawDist = 255;
+    ammoMoby->UpdateDist = 255;
+    ammoMoby->PUpdate = ammodropUpdate;
+    
+    // configure it to be pickup-able
+    if (ammoMoby->PVar) {
+      *(float*)(ammoMoby->PVar + 0x2C) = 2; // radius?
+      *(char*)(ammoMoby->PVar + 0x5C) = 1; // state
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+void ammodropInit(void)
+{
+  memset(ammoDropMobyList, 0, sizeof(ammoDropMobyList));
+  ammoDropMobyListRollingIndex = 0;
+
+  // force ammo drops to local players only
+  POKE_U32(0x003ACC24, 0x8E351A9C);
+  HOOK_JAL(0x003aca8c, &ammodropTargetGetGadgetMaxAmmo);
+
+  // double ammo pickup amount
+  POKE_F32(0x003978C0, 0.3);
+
+  // disable b6 halving of ammo amount
+  POKE_U16(0x003ac2c4, 0x0);
+}

--- a/codegen/rc4/survival/ammodrop.h
+++ b/codegen/rc4/survival/ammodrop.h
@@ -1,0 +1,17 @@
+#ifndef SURVIVAL_AMMODROP_H
+#define SURVIVAL_AMMODROP_H
+
+#include <tamtypes.h>
+#include <libdl/moby.h>
+#include <libdl/math.h>
+#include <libdl/time.h>
+#include <libdl/player.h>
+#include <libdl/math3d.h>
+#include "game.h"
+
+#define MAX_MOB_AMMO_DROPS                    (10)
+
+void ammodropCreateAt(Moby* moby);
+void ammodropInit(void);
+
+#endif // SURVIVAL_AMMODROP_H

--- a/codegen/rc4/survival/ammosupply.c
+++ b/codegen/rc4/survival/ammosupply.c
@@ -1,0 +1,108 @@
+
+/***************************************************
+ * FILENAME :		ammosupply.c
+ * 
+ * DESCRIPTION :
+ * 		Handles logic for the ammo supply machine.
+ * 		
+ * AUTHOR :			Daniel "Dnawrkshp" Gerendasy
+ */
+
+#include <tamtypes.h>
+
+#include <libdl/dl.h>
+#include <libdl/player.h>
+#include <libdl/pad.h>
+#include <libdl/time.h>
+#include <libdl/net.h>
+#include <libdl/game.h>
+#include <libdl/string.h>
+#include <libdl/math.h>
+#include <libdl/random.h>
+#include <libdl/math3d.h>
+#include <libdl/radar.h>
+#include <libdl/stdio.h>
+#include <libdl/gamesettings.h>
+#include <libdl/dialog.h>
+#include <libdl/sound.h>
+#include <libdl/patch.h>
+#include <libdl/ui.h>
+#include <libdl/graphics.h>
+#include <libdl/color.h>
+#include <libdl/utils.h>
+#include "game.h"
+#include "gate.h"
+#include "messageid.h"
+#include "utils.h"
+#include "maputils.h"
+#include "ammosupply.h"
+
+//--------------------------------------------------------------------------
+int ammosupplyGetCost(Moby* moby, Player* player, int gadgetId)
+{
+  if (!moby || !player)
+    return 0;
+
+  struct AmmoSupplyPVar* pvars = (struct AmmoSupplyPVar*)moby->PVar;
+  int maxAmmo = playerGetWeaponMaxAmmo(player->GadgetBox, gadgetId);
+  int currentAmmo = player->GadgetBox->Gadgets[gadgetId].Ammo;
+  int purchaseAmmoAmt = maxAmmo - currentAmmo;
+  if (purchaseAmmoAmt <= 0) return 0;
+  
+  // convert gadget id to index in cost array
+  int slotId = weaponIdToSlot(gadgetId) - 1;
+  if (slotId < 0 || slotId > (WEAPON_SLOT_COUNT-1)) return 0;
+
+  // get base cost per ammo
+  int baseCost = pvars->BaseCost[slotId];
+  if (player->GadgetBox->Gadgets[gadgetId].Level >= 9)
+    baseCost = pvars->BaseCostV10[slotId];
+
+  return baseCost * purchaseAmmoAmt;
+}
+
+//--------------------------------------------------------------------------
+void ammosupplyUpdate(Moby* moby)
+{
+  int i;
+  char buf[48];
+  if (!moby || !moby->PVar)
+    return;
+    
+  struct AmmoSupplyPVar* pvars = (struct AmmoSupplyPVar*)moby->PVar;
+
+  // find local players to activate
+  for (i = 0; i < GAME_MAX_LOCALS; ++i) {
+    Player* player = playerGetFromSlot(i);
+    if (!playerIsValid(player)) continue;
+
+    int weaponId = player->WeaponHeldId;
+    int cost = ammosupplyGetCost(moby, player, weaponId);
+    if (cost <= 0) continue;
+
+    snprintf(buf, sizeof(buf), "\x11 Refill Ammo [\x0E%'d\x08]", cost);
+    if (tryPlayerInteract(moby, player, buf, NULL, cost, 0, 30, 9, PAD_CIRCLE)) {
+      player->GadgetBox->Gadgets[weaponId].Ammo = playerGetWeaponMaxAmmo(player->GadgetBox, weaponId);
+      MapConfig.State->PlayerStates[player->PlayerId].State.Bolts -= cost;
+      playPaidSound(player);
+      break;
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+void ammosupplyInit(void)
+{
+  // set update func
+  Moby* moby = mobyListGetStart();
+	while ((moby = mobyFindNextByOClass(moby, AMMO_SUPPLY_OCLASS)))
+	{
+		if (!mobyIsDestroyed(moby)) {
+      moby->PUpdate = &ammosupplyUpdate;
+      moby->ModeBits &= ~MOBY_MODE_BIT_NO_UPDATE;
+      DPRINTF("ammosupply found %08X\n", (u32)moby);
+    }
+
+		++moby;
+	}
+}

--- a/codegen/rc4/survival/ammosupply.h
+++ b/codegen/rc4/survival/ammosupply.h
@@ -1,0 +1,21 @@
+#ifndef SURVIVAL_AMMO_SUPPLY_H
+#define SURVIVAL_AMMO_SUPPLY_H
+
+#include <tamtypes.h>
+#include <libdl/moby.h>
+#include <libdl/math.h>
+#include <libdl/time.h>
+#include <libdl/player.h>
+#include <libdl/math3d.h>
+
+#define AMMO_SUPPLY_OCLASS                      (0x01FF)
+
+struct AmmoSupplyPVar
+{
+  u32 BaseCost[WEAPON_SLOT_COUNT-1]; // base ammo cost for each weapon
+  u32 BaseCostV10[WEAPON_SLOT_COUNT-1]; // base ammo cost for each v10 weapon
+};
+
+void ammosupplyInit(void);
+
+#endif // SURVIVAL_AMMO_SUPPLY_H

--- a/codegen/rc4/survival/mob.h
+++ b/codegen/rc4/survival/mob.h
@@ -16,6 +16,8 @@
 #include "leviathan.h"
 #include "game.h"
 
+#define MOB_MAX_OTHER_TARGETS       (32)
+
 enum MobAttributeType
 {
   MOB_ATTRIBUTE_NONE = 0,
@@ -59,6 +61,35 @@ enum MobSpawnFlags {
 // 
 enum MobUnreliableMsgId {
   MOB_UNRELIABLE_MSG_ID_STATE_UPDATE
+};
+
+// 
+enum MobTargetingRules
+{
+  MOB_TARGET_BIT_NEAREST = 0x00,
+  MOB_TARGET_BIT_STRONGEST = 0x01,
+  MOB_TARGET_BIT_WEAKEST = 0x02,
+  MOB_TARGET_BIT_ANY = 0x00,
+  MOB_TARGET_BIT_PLAYER = 0x10,
+  MOB_TARGET_BIT_OTHER = 0x20,
+
+  MOB_TARGET_MASK_STRATEGY = 0x0f,
+  MOB_TARGET_MASK_TARGET = 0xf0,
+
+  // ANY
+  MOB_TARGET_NEAREST_ANY = (MOB_TARGET_BIT_ANY | MOB_TARGET_BIT_NEAREST),
+  MOB_TARGET_STRONGEST_ANY = (MOB_TARGET_BIT_ANY | MOB_TARGET_BIT_STRONGEST),
+  MOB_TARGET_WEAKEST_ANY = (MOB_TARGET_BIT_ANY | MOB_TARGET_BIT_WEAKEST),
+
+  // PLAYER
+  MOB_TARGET_NEAREST_PLAYER = (MOB_TARGET_BIT_PLAYER | MOB_TARGET_BIT_NEAREST),
+  MOB_TARGET_STRONGEST_PLAYER = (MOB_TARGET_BIT_PLAYER | MOB_TARGET_BIT_STRONGEST),
+  MOB_TARGET_WEAKEST_PLAYER = (MOB_TARGET_BIT_PLAYER | MOB_TARGET_BIT_WEAKEST),
+
+  // OTHER
+  MOB_TARGET_NEAREST_OTHER = (MOB_TARGET_BIT_OTHER | MOB_TARGET_BIT_NEAREST),
+  MOB_TARGET_STRONGEST_OTHER = (MOB_TARGET_BIT_OTHER | MOB_TARGET_BIT_STRONGEST),
+  MOB_TARGET_WEAKEST_OTHER = (MOB_TARGET_BIT_OTHER | MOB_TARGET_BIT_WEAKEST),
 };
 
 struct MobDamageEventArgs;
@@ -250,6 +281,7 @@ struct MobVars {
   char DynamicRandom;
   char BlipType;
   char NoTargetCounter;
+  char TargetingRule;
 };
 
 // warning: multiple differing types with the same name, only one recovered
@@ -384,8 +416,10 @@ struct MobUnreliableMsgStateUpdateArgs
   struct MobStateUpdateEventArgs StateUpdate;
 };
 
+float mobGetTargetRadius(Moby* target);
+float mobGetDistanceToTarget(Moby* moby, Moby* target);
 int mobOnUnreliableMsgRemote(void* connection, void* data);
-void mobReactToExplosionAt(int byPlayerId, VECTOR position, float damage, float radius);
+void mobReactToExplosionAt(Moby* damager, VECTOR position, float damage, float radius, int bKnockback);
 void mobNuke(int killedByPlayerId);
 int mobHandleEvent(Moby* moby, GuberEvent* event);
 int mobCreate(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, int spawnFlags, struct MobConfig *config);

--- a/codegen/rc4/survival/mobs/executioner.c
+++ b/codegen/rc4/survival/mobs/executioner.c
@@ -335,26 +335,24 @@ int executionerGetPreferredAction(Moby* moby, int * delayTicks)
 	// get next target
 	Moby * target = executionerGetNextTarget(moby);
 	if (target) {
-		vector_copy(t, target->Position);
-		vector_subtract(t, t, moby->Position);
-		float distSqr = vector_sqrmag(t);
-		float attackRadiusSqr = pvars->MobVars.Config.AttackRadius * pvars->MobVars.Config.AttackRadius;
-    float rangedAttackRadiusSqr = powf(MapConfig.DefaultSpawnParams[pvars->MobVars.SpawnParamsIdx].RangedAttackDistance, 2);
+    float dist = mobGetDistanceToTarget(moby, target);
+		float attackRadius = pvars->MobVars.Config.AttackRadius;
+    float rangedAttackRadius = MapConfig.DefaultSpawnParams[pvars->MobVars.SpawnParamsIdx].RangedAttackDistance;
     int preferredRanged = mobGetBehavior(moby) == EXECUTIONER_BEHAVIOR_RANGED;
     int canRanged = mobGetBehavior(moby) == EXECUTIONER_BEHAVIOR_NORMAL || preferredRanged;
 
     if (1) {
-      if (distSqr <= attackRadiusSqr) {
+      if (dist <= attackRadius) {
         // near target, swing
-        if (executionerCanAttack(pvars) && distSqr > (EXECUTIONER_TOO_CLOSE_TO_TARGET_RADIUS*EXECUTIONER_TOO_CLOSE_TO_TARGET_RADIUS)) {
+        if (executionerCanAttack(pvars) && dist > (EXECUTIONER_TOO_CLOSE_TO_TARGET_RADIUS)) {
           if (delayTicks) *delayTicks = pvars->MobVars.Config.ReactionTickCount;
           return EXECUTIONER_ACTION_ATTACK;
         }
         return EXECUTIONER_ACTION_WALK;
-      } else if (!preferredRanged && distSqr <= (attackRadiusSqr*4) && rand(101)) {
+      } else if (!preferredRanged && dist <= (attackRadius*2) && rand(101)) {
         // chase most of the time, sometimes defer to ranged attack
         return EXECUTIONER_ACTION_WALK;
-      } else if (canRanged && distSqr <= rangedAttackRadiusSqr && mobCanSeeMoby(moby, target)) {
+      } else if (canRanged && dist <= rangedAttackRadius && mobCanSeeMoby(moby, target)) {
         // away from target
         // check if facing
         // and fire

--- a/codegen/rc4/survival/mobs/leviathan.c
+++ b/codegen/rc4/survival/mobs/leviathan.c
@@ -458,11 +458,11 @@ enum LeviathanAction leviathanGetPreferredAttack(Moby* moby)
 
   vector_scale(dt, moby->M0_03, 1 * 2);
   vector_add(inFrontPos, moby->Position, dt);
-  vector_subtract(dt, inFrontPos, pvars->MobVars.Target->Position);
-  float sqrDist = vector_sqrmag(dt);
-  if (sqrDist < 1) {
+  vector_subtract(dt, inFrontPos, target->Position);
+  float dist = vector_length(dt) - mobGetTargetRadius(target);
+  if (dist < 1) {
     return LEVIATHAN_ACTION_ATTACK_STAB;
-  } else if (sqrDist < attackRadiusSqr) {
+  } else if (dist < pvars->MobVars.Config.AttackRadius) {
     return LEVIATHAN_ACTION_ATTACK_SWING;
   }
 

--- a/codegen/rc4/survival/mobs/mob.c
+++ b/codegen/rc4/survival/mobs/mob.c
@@ -23,6 +23,7 @@
 #include "mob.h"
 #include "utils.h"
 #include "gate.h"
+#include "dummy.h"
 #include "maputils.h"
 #include "shared.h"
 #include "pathfind.h"
@@ -76,7 +77,21 @@ VECTOR MoveNextPos;
 VECTOR MoveTargetLineOfSightHit;
 #endif
 
+Moby* mobOtherTargets[MOB_MAX_OTHER_TARGETS];
+Moby* mobOtherTargets2[MOB_MAX_OTHER_TARGETS];
 int mobMoveCheckCollideWithOtherMobsRotatingIndex = 0;
+
+//--------------------------------------------------------------------------
+void mobRegisterTarget(Moby* moby)
+{
+  int i;
+  for (i = 0; i < MOB_MAX_OTHER_TARGETS; ++i) {
+    if (!mobOtherTargets2[i]) {
+      mobOtherTargets2[i] = moby;
+      return;
+    }
+  }
+}
 
 //--------------------------------------------------------------------------
 int mobAmIOwner(Moby* moby)
@@ -116,6 +131,19 @@ float mobGetScaleMultiplier(Moby* moby)
 }
 
 //--------------------------------------------------------------------------
+GuberEvent* mobCreateEvent(Moby* moby, u32 eventType)
+{
+  GuberEvent * event = NULL;
+
+  // create guber object
+  Guber* guber = guberGetObjectByMoby(moby);
+  if (guber)
+    event = guberEventCreateEvent(guber, eventType, 0, 0);
+
+  return event;
+}
+
+//--------------------------------------------------------------------------
 void mobSpawnCorn(Moby* moby, int bangle)
 {
 #if MOB_CORN
@@ -149,6 +177,32 @@ void mobResetSoundTrigger(Moby* moby)
 {
   moby->SoundTrigger = 0;
   moby->SoundDesired = -1;
+}
+
+//--------------------------------------------------------------------------
+float mobGetTargetRadius(Moby* target)
+{
+	if (!target) return 0;
+
+  Player* player = guberMobyGetPlayerDamager(target);
+  if (player) return player->Coll.radius;
+
+  return target->BSphere[3] / 1024.0;
+}
+
+//--------------------------------------------------------------------------
+float mobGetDistanceToTarget(Moby* moby, Moby* target)
+{
+	struct MobPVar* pvars = (struct MobPVar*)moby->PVar;
+  VECTOR t;
+
+	if (!target) return 0;
+
+  vector_copy(t, target->Position);
+  vector_subtract(t, t, moby->Position);
+  float dist = vector_length(t) - mobGetTargetRadius(target);
+  
+  return maxf(0, dist);
 }
 
 //--------------------------------------------------------------------------
@@ -223,6 +277,50 @@ float mobGetCurrentMoveSpeed(Moby* moby)
 }
 
 //--------------------------------------------------------------------------
+void mobReactToExplosionAt(Moby* damager, VECTOR position, float damage, float radius, int bKnockback)
+{
+  if (!MapConfig.State) return;
+
+  int i;
+  VECTOR delta;
+  struct MobDamageEventArgs args;
+  float sqrRadius = radius * radius;
+  Player** players = playerGetAll();
+  u32 uid = 0;
+  if (damager) uid = guberGetUID(damager);
+
+  memset(&args, 0, sizeof(args));
+  for (i = 0; i < MAX_MOBS_ALIVE; ++i) {
+    Moby* m = MapConfig.State->AllMobsSorted[i];
+    if (m) {
+      
+      vector_subtract(delta, m->Position, position);
+      if (vector_sqrmag(delta) <= sqrRadius) {
+        
+        float dist = vector_length(delta);
+        float angle = atan2f(delta[1] / dist, delta[0] / dist);
+        
+        // create event
+        GuberEvent * guberEvent = mobCreateEvent(m, MOB_EVENT_DAMAGE);
+        if (guberEvent) {
+          args.SourceUID = uid;
+          args.SourceOClass = 0;
+          args.DamageQuarters = damage*4;
+          args.DamageFlags = 0;
+          if (bKnockback) {
+            args.Knockback.Angle = (short)(angle * 1000);
+            args.Knockback.Ticks = 10;
+            args.Knockback.Power = 6;
+            args.Knockback.Force = 1;
+          }
+          guberEventWrite(guberEvent, &args, sizeof(struct MobDamageEventArgs));
+        }
+      }
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
 void mobReactToThorns(Moby* moby, float damage, int byPlayerId)
 {
   if (byPlayerId < 0) return;
@@ -281,21 +379,30 @@ int mobMobyProcessHitFlags(Moby* moby, Moby* hitMoby, float damage, int reactToT
 }
 
 //--------------------------------------------------------------------------
-int mobDoDamageTryHit(Moby* moby, Moby* hitMoby, VECTOR jointPosition, int isAoE, float sqrHitRadius, int damageFlags, float amount)
+int mobDoDamageTryHit(Moby* moby, Moby* hitMoby, VECTOR jointPosition, int isAoE, float hitRadius, int damageFlags, float amount)
 {
   VECTOR mobToHitMoby, mobToJoint, jointToHitMoby;
   VECTOR hitMobyCenter = {0,0,1,0};
   MATRIX playerJointMtx;
   Player* player = guberMobyGetPlayerDamager(hitMoby);
+  struct TargetVars* targetVars = mobyGetTargetVars(hitMoby);
 	MobyColDamageIn in;
-  float hitMobyCollRadiusSqr = 0;
+  float hitMobyCollRadius = 0;
+  float hitHeight = 0.25;
 
   if (player && player->PlayerMoby) {
     mobyGetJointMatrix(player->PlayerMoby, 10, playerJointMtx);
     vector_copy(hitMobyCenter, &playerJointMtx[12]);
     hitMobyCenter[2] = clamp(jointPosition[2], playerJointMtx[14] - player->Coll.bot, playerJointMtx[14] + player->Coll.top);
-    hitMobyCollRadiusSqr = player->Coll.radiusSqd;
+    hitMobyCollRadius = player->Coll.radius;
   } else {
+    hitMobyCollRadius = hitMoby->BSphere[3] / 1024.0;
+    if (targetVars) {
+      vector_scale(hitMobyCenter, hitMoby->M2_03, targetVars->targetHeight);
+      hitHeight = 1 + maxf(targetVars->targetHeight, hitHeight);
+      //hitMobyCollRadius = (u8)targetVars->targetRadiusIn8ths / 8.0;
+    }
+
     vector_add(hitMobyCenter, hitMobyCenter, hitMoby->Position);
   }
 
@@ -308,11 +415,11 @@ int mobDoDamageTryHit(Moby* moby, Moby* hitMoby, VECTOR jointPosition, int isAoE
     return 0;
 
   // clamp within arbitrary vertical limit
-  if (!isAoE && fabsf(jointToHitMoby[2]) > 0.25)
+  if (!isAoE && fabsf(jointToHitMoby[2]) > hitHeight)
     return 0;
 
   // ignore if past attack radius
-  if (vector_innerproduct(mobToHitMoby, jointToHitMoby) > 0 && vector_sqrmag(jointToHitMoby) > (hitMobyCollRadiusSqr + sqrHitRadius))
+  if (vector_innerproduct(mobToHitMoby, jointToHitMoby) > 0 && vector_length(jointToHitMoby) > (hitMobyCollRadius + hitRadius))
     return 0;
 
   vector_write(in.Momentum, 0);
@@ -338,7 +445,8 @@ int mobDoSweepDamage(Moby* moby, VECTOR from, VECTOR to, float step, float radiu
   int result = 0;
   float t = 0;
   float sqrRadius = radius * radius;
-  float firstPassSqrRadius = powf(5 + radius, 2);
+  float firstPassRadius = 5 + radius;
+  float firstPassSqrRadius = powf(firstPassRadius, 2);
 
   // get total distance to travel
   vector_subtract(delta, to, from);
@@ -351,6 +459,20 @@ int mobDoSweepDamage(Moby* moby, VECTOR from, VECTOR to, float step, float radiu
     // if no friendly fire just check hit on players
     // otherwise check all mobys
     if (!friendlyFire) {
+      for (i = 0; i < MOB_MAX_OTHER_TARGETS; ++i) {
+        Moby* otherTarget = mobOtherTargets[i];
+        if (!otherTarget) break;
+
+        float otherTargetRadius = otherTarget->BSphere[3] / 1024.0;
+        vector_subtract(delta, otherTarget->Position, p);
+        if ((vector_length(delta)-otherTargetRadius) > firstPassRadius)
+          continue;
+
+        if (mobDoDamageTryHit(moby, otherTarget, p, isAoE, radius, damageFlags, amount)) {
+          result |= mobMobyProcessHitFlags(moby, otherTarget, amount, reactToThorns);
+        }
+      }
+
       for (i = 0; i < GAME_MAX_PLAYERS; ++i) {
         Player* player = players[i];
         if (!player || !player->SkinMoby || playerIsDead(player))
@@ -360,7 +482,7 @@ int mobDoSweepDamage(Moby* moby, VECTOR from, VECTOR to, float step, float radiu
         if (vector_sqrmag(delta) > firstPassSqrRadius)
           continue;
 
-        if (mobDoDamageTryHit(moby, player->PlayerMoby, p, isAoE, sqrRadius, damageFlags, amount)) {
+        if (mobDoDamageTryHit(moby, player->PlayerMoby, p, isAoE, radius, damageFlags, amount)) {
           result |= mobMobyProcessHitFlags(moby, player->PlayerMoby, amount, reactToThorns);
         }
       }
@@ -368,7 +490,7 @@ int mobDoSweepDamage(Moby* moby, VECTOR from, VECTOR to, float step, float radiu
       Moby** hitMobies = CollMobysSphere_Fix_GetHitMobies();
       Moby* hitMoby;
       while ((hitMoby = *hitMobies++)) {
-        if (mobDoDamageTryHit(moby, hitMoby, p, isAoE, sqrRadius, damageFlags, amount)) {
+        if (mobDoDamageTryHit(moby, hitMoby, p, isAoE, radius, damageFlags, amount)) {
           result |= mobMobyProcessHitFlags(moby, hitMoby, amount, reactToThorns);
         }
       }
@@ -388,6 +510,7 @@ int mobDoDamage(Moby* moby, float radius, float amount, int damageFlags, int fri
   int i;
   int result = 0;
   float sqrRadius = radius * radius;
+  float firstPassRadius = 5 + radius;
   float firstPassSqrRadius = powf(5 + radius, 2);
 
   // get position of right spike joint
@@ -397,6 +520,20 @@ int mobDoDamage(Moby* moby, float radius, float amount, int damageFlags, int fri
   // if no friendly fire just check hit on players
   // otherwise check all mobys
   if (!friendlyFire) {
+    for (i = 0; i < MOB_MAX_OTHER_TARGETS; ++i) {
+      Moby* otherTarget = mobOtherTargets[i];
+      if (!otherTarget) break;
+
+      float otherTargetRadius = otherTarget->BSphere[3] / 1024.0;
+      vector_subtract(delta, otherTarget->Position, p);
+      if ((vector_length(delta)-otherTargetRadius) > firstPassRadius)
+        continue;
+
+      if (mobDoDamageTryHit(moby, otherTarget, p, isAoE, radius, damageFlags, amount)) {
+        result |= mobMobyProcessHitFlags(moby, otherTarget, amount, reactToThorns);
+      }
+    }
+    
     for (i = 0; i < GAME_MAX_PLAYERS; ++i) {
       Player* player = players[i];
       if (!player || !playerIsConnected(player) || playerIsDead(player))
@@ -406,7 +543,7 @@ int mobDoDamage(Moby* moby, float radius, float amount, int damageFlags, int fri
       if (vector_sqrmag(delta) > firstPassSqrRadius)
         continue;
 
-      if (mobDoDamageTryHit(moby, player->PlayerMoby, p, isAoE, sqrRadius, damageFlags, amount)) {
+      if (mobDoDamageTryHit(moby, player->PlayerMoby, p, isAoE, radius, damageFlags, amount)) {
         result |= mobMobyProcessHitFlags(moby, player->PlayerMoby, amount, reactToThorns);
       }
     }
@@ -414,7 +551,7 @@ int mobDoDamage(Moby* moby, float radius, float amount, int damageFlags, int fri
     Moby** hitMobies = CollMobysSphere_Fix_GetHitMobies();
     Moby* hitMoby;
     while ((hitMoby = *hitMobies++)) {
-      if (mobDoDamageTryHit(moby, hitMoby, p, isAoE, sqrRadius, damageFlags, amount)) {
+      if (mobDoDamageTryHit(moby, hitMoby, p, isAoE, radius, damageFlags, amount)) {
         result |= mobMobyProcessHitFlags(moby, hitMoby, amount, reactToThorns);
       }
     }
@@ -622,7 +759,9 @@ int mobMoveCheck(Moby* moby, VECTOR outputPos, VECTOR from, VECTOR to)
     if (pvars->MobVars.MoveVars.WallSlope > (60 * MATH_DEG2RAD)) {
       //vector_projectonhorizontal(hitToEx, hitToEx);
       //vector_subtract(outputPos, to, hitToEx);
+#if DEBUG_MOVE
       DPRINTF("movecheck hit steep slope %f\n", pvars->MobVars.MoveVars.WallSlope * MATH_RAD2DEG);
+#endif
       //return 2;
     }
 
@@ -954,7 +1093,7 @@ void mobGetVelocityToTargetWithDirection(Moby* moby, VECTOR velocity, VECTOR fro
 
   Moby* target = pvars->MobVars.Target;
   if (target) {
-    targetRadius = (target->BSphere[3] / 1024) * 0.5;
+    targetRadius = (target->BSphere[3] / 1024) * 1;
   }
 
   // target velocity from rotation
@@ -1045,45 +1184,69 @@ Moby* mobGetNextTarget(Moby* moby, float keepCurrentTargetFactor)
 	int i;
 	VECTOR delta;
 	Moby * currentTarget = pvars->MobVars.Target;
-	Player * closestPlayer = NULL;
-	float closestPlayerDist = 100000;
+	Moby * bestTargetMoby = NULL;
+	float closestTargetDist = 100000;
+  int targetAny = (pvars->MobVars.TargetingRule & MOB_TARGET_MASK_TARGET) == MOB_TARGET_BIT_ANY;
+  int targetOther = (pvars->MobVars.TargetingRule & MOB_TARGET_MASK_TARGET) == MOB_TARGET_BIT_OTHER || targetAny;
+  int targetPlayer = (pvars->MobVars.TargetingRule & MOB_TARGET_MASK_TARGET) == MOB_TARGET_BIT_PLAYER || targetAny;
+  
+  // check nearest other targets
+  if (targetOther) {
+    for (i = 0; i < MOB_MAX_OTHER_TARGETS; ++i) {
+      Moby* otherTarget = mobOtherTargets[i];
+      if (!otherTarget) break;
+      if (otherTarget->OClass != DUMMY_OCLASS) break;
 
-	for (i = 0; i < GAME_MAX_PLAYERS; ++i) {
-		Player* p = players[i];
-		if (p && p->SkinMoby && !playerIsDead(p) && p->Health > 0 && p->SkinMoby->Opacity >= 0x80) {
-			vector_subtract(delta, p->PlayerPosition, moby->Position);
-			float dist = vector_length(delta);
+      struct DummyPVar* otherPVars = (struct DummyPVar*)otherTarget->PVar;
+      if ((!currentTarget || currentTarget == otherTarget) && otherPVars->Config.MobTargetType == DUMMY_MOB_AGGRO_ALWAYS) {
+        return otherTarget;
+      }
 
-			if (dist < 300) {
-        Moby* pTargetMoby = playerGetTargetMoby(p);
-
-        // don't target players that are in jump pad state
-        // unless we're already targeting them
-        if (p->PlayerState == PLAYER_STATE_MOON_JUMP && pTargetMoby != currentTarget)
-          continue;
-
-				// favor existing target
-				if (pTargetMoby == currentTarget)
-					dist *= (1.0 / keepCurrentTargetFactor);
-				
-				// pick closest target
-				if (dist < closestPlayerDist) {
-
-          // confirm we can walk to target
-          if (pathHasRouteToTarget(moby, pTargetMoby)) {
-            closestPlayer = p;
-            closestPlayerDist = dist;
-          }
-				}
-			}
-		}
-	}
-
-	if (closestPlayer) {
-    return playerGetTargetMoby(closestPlayer);
+      vector_subtract(delta, otherTarget->Position, moby->Position);
+      float dist = vector_length(delta);
+      float maxDist = otherPVars->Config.MobTargetDistance*otherPVars->Config.MobTargetDistance;
+      if (otherPVars->Config.MobTargetType == DUMMY_MOB_AGGRO_IN_RANGE && dist < maxDist) {
+        bestTargetMoby = otherTarget;
+        closestTargetDist = dist;
+      }
+    }
   }
 
-	return NULL;
+  // check nearest players
+  if (targetPlayer) {
+    for (i = 0; i < GAME_MAX_PLAYERS; ++i) {
+      Player* p = players[i];
+      if (p && p->SkinMoby && !playerIsDead(p) && p->Health > 0 && p->SkinMoby->Opacity >= 0x80) {
+        vector_subtract(delta, p->PlayerPosition, moby->Position);
+        float dist = vector_length(delta);
+
+        if (dist < 300) {
+          Moby* pTargetMoby = playerGetTargetMoby(p);
+
+          // don't target players that are in jump pad state
+          // unless we're already targeting them
+          if (p->PlayerState == PLAYER_STATE_MOON_JUMP && pTargetMoby != currentTarget)
+            continue;
+
+          // favor existing target
+          if (pTargetMoby == currentTarget)
+            dist *= (1.0 / keepCurrentTargetFactor);
+          
+          // pick closest target
+          if (dist < closestTargetDist) {
+
+            // confirm we can walk to target
+            if (pathHasRouteToTarget(moby, pTargetMoby)) {
+              bestTargetMoby = pTargetMoby;
+              closestTargetDist = dist;
+            }
+          }
+        }
+      }
+    }
+  }
+
+	return bestTargetMoby;
 }
 
 //--------------------------------------------------------------------------
@@ -1324,4 +1487,8 @@ void mobTick(void)
     mobMoveCheckCollideWithOtherMobsRotatingIndex = (mobMoveCheckCollideWithOtherMobsRotatingIndex + 1) % MapConfig.State->MobStats.TotalAlive;
   else
     mobMoveCheckCollideWithOtherMobsRotatingIndex = (mobMoveCheckCollideWithOtherMobsRotatingIndex + 1) % MAX_MOBS_ALIVE;
+
+  // flip targets
+  memcpy(mobOtherTargets, mobOtherTargets2, sizeof(mobOtherTargets));
+  memset(mobOtherTargets2, 0, sizeof(mobOtherTargets2));
 }

--- a/codegen/rc4/survival/mobs/reactor.c
+++ b/codegen/rc4/survival/mobs/reactor.c
@@ -549,17 +549,16 @@ int reactorGetPreferredAction(Moby* moby, int * delayTicks)
       return REACTOR_ACTION_WALK;
     }
 
-		vector_subtract(t, target->Position, moby->Position);
-		float distSqr = vector_sqrmag(t);
-		float attackRadiusSqr = pvars->MobVars.Config.AttackRadius * pvars->MobVars.Config.AttackRadius;
+    float dist = mobGetDistanceToTarget(moby, target);
+		float attackRadius = pvars->MobVars.Config.AttackRadius;
 
     // if we're on top of the target then step away
-    if (distSqr < (REACTOR_BASE_COLL_RADIUS*REACTOR_BASE_COLL_RADIUS)) {
+    if (dist < (REACTOR_BASE_COLL_RADIUS)) {
       return REACTOR_ACTION_WALK;
     }
 
     // near then swing
-		if (distSqr <= attackRadiusSqr && reactorCanAttack(pvars, REACTOR_ACTION_ATTACK_SWING)) {
+		if (dist <= attackRadius && reactorCanAttack(pvars, REACTOR_ACTION_ATTACK_SWING)) {
       if (delayTicks) *delayTicks = pvars->MobVars.Config.ReactionTickCount;
       return REACTOR_ACTION_ATTACK_SWING;
 		}
@@ -575,13 +574,13 @@ int reactorGetPreferredAction(Moby* moby, int * delayTicks)
       }
 
       // near but not for swing then charge
-      if (distSqr <= (REACTOR_MAX_DIST_FOR_CHARGE*REACTOR_MAX_DIST_FOR_CHARGE) && rand(5) == 0 && reactorCanAttack(pvars, REACTOR_ACTION_ATTACK_CHARGE)) {
+      if (dist <= (REACTOR_MAX_DIST_FOR_CHARGE) && rand(5) == 0 && reactorCanAttack(pvars, REACTOR_ACTION_ATTACK_CHARGE)) {
         if (delayTicks) *delayTicks = pvars->MobVars.Config.ReactionTickCount;
         return REACTOR_ACTION_ATTACK_CHARGE;
       }
 
       // far but in sight, shoot with trail
-      if (distSqr <= (REACTOR_SHOT_WITH_TRAIL_MAX_DIST*REACTOR_SHOT_WITH_TRAIL_MAX_DIST) && rand(5) == 0 && reactorCanAttack(pvars, REACTOR_ACTION_ATTACK_SHOT_WITH_TRAIL)) {
+      if (dist <= (REACTOR_SHOT_WITH_TRAIL_MAX_DIST) && rand(5) == 0 && reactorCanAttack(pvars, REACTOR_ACTION_ATTACK_SHOT_WITH_TRAIL)) {
         if (delayTicks) *delayTicks = pvars->MobVars.Config.ReactionTickCount;
         return REACTOR_ACTION_ATTACK_SHOT_WITH_TRAIL;
       }

--- a/codegen/rc4/survival/mobs/reaper.c
+++ b/codegen/rc4/survival/mobs/reaper.c
@@ -355,12 +355,10 @@ int reaperGetPreferredAction(Moby* moby, int * delayTicks)
 	// get next target
 	Moby * target = reaperGetNextTarget(moby);
 	if (target) {
-		vector_copy(t, target->Position);
-		vector_subtract(t, t, moby->Position);
-		float distSqr = vector_sqrmag(t);
-		float attackRadiusSqr = pvars->MobVars.Config.AttackRadius * pvars->MobVars.Config.AttackRadius;
+    float dist = mobGetDistanceToTarget(moby, target);
+		float attackRadius = pvars->MobVars.Config.AttackRadius;
 
-		if (distSqr <= attackRadiusSqr) {
+		if (dist <= attackRadius) {
 			if (reaperCanAttack(pvars)) {
         if (delayTicks) *delayTicks = pvars->MobVars.Config.ReactionTickCount;
 				return REAPER_ACTION_ATTACK;

--- a/codegen/rc4/survival/mobs/swarmer.c
+++ b/codegen/rc4/survival/mobs/swarmer.c
@@ -348,12 +348,10 @@ int swarmerGetPreferredAction(Moby* moby, int * delayTicks)
 	// get next target
 	Moby * target = swarmerGetNextTarget(moby);
 	if (target) {
-		vector_copy(t, target->Position);
-		vector_subtract(t, t, moby->Position);
-		float distSqr = vector_sqrmag(t);
-		float attackRadiusSqr = pvars->MobVars.Config.AttackRadius * pvars->MobVars.Config.AttackRadius;
+    float dist = mobGetDistanceToTarget(moby, target);
+		float attackRadius = pvars->MobVars.Config.AttackRadius;
 
-		if (distSqr <= attackRadiusSqr) {
+		if (dist <= attackRadius) {
 			if (swarmerCanAttack(pvars)) {
         if (delayTicks) *delayTicks = pvars->MobVars.Config.ReactionTickCount;
 				return pvars->MobVars.Config.MobAttribute != MOB_ATTRIBUTE_EXPLODE ? SWARMER_ACTION_ATTACK : SWARMER_ACTION_TIME_BOMB;

--- a/codegen/rc4/survival/mobs/tremor.c
+++ b/codegen/rc4/survival/mobs/tremor.c
@@ -322,12 +322,10 @@ int tremorGetPreferredAction(Moby* moby, int * delayTicks)
 	// get next target
 	Moby * target = tremorGetNextTarget(moby);
 	if (target) {
-		vector_copy(t, target->Position);
-		vector_subtract(t, t, moby->Position);
-		float distSqr = vector_sqrmag(t);
-		float attackRadiusSqr = pvars->MobVars.Config.AttackRadius * pvars->MobVars.Config.AttackRadius;
+    float dist = mobGetDistanceToTarget(moby, target);
+		float attackRadius = pvars->MobVars.Config.AttackRadius;
 
-		if (distSqr <= attackRadiusSqr) {
+		if (dist <= attackRadius) {
 			if (tremorCanAttack(pvars)) {
         if (delayTicks) *delayTicks = pvars->MobVars.Config.ReactionTickCount;
 				return TREMOR_ACTION_ATTACK;

--- a/codegen/rc4/survival/mobs/zombie.c
+++ b/codegen/rc4/survival/mobs/zombie.c
@@ -337,12 +337,10 @@ int zombieGetPreferredAction(Moby* moby, int * delayTicks)
 	// get next target
 	Moby * target = zombieGetNextTarget(moby);
 	if (target) {
-		vector_copy(t, target->Position);
-		vector_subtract(t, t, moby->Position);
-		float distSqr = vector_sqrmag(t);
-		float attackRadiusSqr = pvars->MobVars.Config.AttackRadius * pvars->MobVars.Config.AttackRadius;
+    float dist = mobGetDistanceToTarget(moby, target);
+		float attackRadius = pvars->MobVars.Config.AttackRadius;
 
-		if (distSqr <= attackRadiusSqr) {
+		if (dist <= attackRadius) {
 			if (zombieCanAttack(pvars)) {
         if (delayTicks) *delayTicks = pvars->MobVars.Config.ReactionTickCount;
 				return pvars->MobVars.Config.MobAttribute != MOB_ATTRIBUTE_EXPLODE ? ZOMBIE_ACTION_ATTACK : ZOMBIE_ACTION_TIME_BOMB;

--- a/codegen/rc4/survival/shared.h
+++ b/codegen/rc4/survival/shared.h
@@ -26,7 +26,7 @@ void mobResetSoundTrigger(Moby* moby);
 void mobSpawnCorn(Moby* moby, int bangle);
 int mobDoDamage(Moby* moby, float radius, float amount, int damageFlags, int friendlyFire, int jointId, int reactToThorns, int isAoE);
 int mobDoSweepDamage(Moby* moby, VECTOR from, VECTOR to, float step, float radius, float amount, int damageFlags, int friendlyFire, int reactToThorns, int isAoE);
-int mobDoDamageTryHit(Moby* moby, Moby* hitMoby, VECTOR jointPosition, int isAoE, float sqrHitRadius, int damageFlags, float amount);
+int mobDoDamageTryHit(Moby* moby, Moby* hitMoby, VECTOR jointPosition, int isAoE, float hitRadius, int damageFlags, float amount);
 void mobSetAction(Moby* moby, int action);
 void mobTransAnimLerp(Moby* moby, int animId, int lerpFrames, float startOff);
 void mobTransAnim(Moby* moby, int animId, float startOff);

--- a/codegen/rc4/survival/survival.c
+++ b/codegen/rc4/survival/survival.c
@@ -40,6 +40,8 @@
 #include "upgrade.h"
 #include "drop.h"
 #include "pool.h"
+#include "ammosupply.h"
+#include "ammodrop.h"
 
 #if SOULCOLLECTOR
 #include "soulcollector.h"
@@ -70,7 +72,10 @@ void blessingsTick(void);
 void stackableOnMobKilled(Moby* moby, int killedByPlayerId, int killedByWeaponId);
 
 void frameTick(void);
+int createMob(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, int spawnFlags, struct MobConfig *config);
 void mapOnMobKilled(Moby* moby, int killedByPlayerId, int killedByWeaponId);
+int mapConsiderMobSpawnPoint(struct MobSpawnParams* mobSpawnParams, VECTOR position, float yaw, Player* targetPlayer);
+int mapGetSpawnPoints(int** outSpawnPointIndices);
 int mapCanSpawnMobs(void);
 
 char LocalPlayerStrBuffer[GAME_MAX_LOCALS][64];
@@ -102,8 +107,11 @@ struct SurvivalMapConfig MapConfig __attribute__((section(".config"))) = {
 	.State = NULL,
   .BakedConfig = &bakedConfig,
   .OnFrameTickFunc = &frameTick,
+  .OnMobCreateFunc = &createMob,
   .OnMobKilledFunc = &mapOnMobKilled,
   .CanSpawnMobsFunc = &mapCanSpawnMobs,
+  .GetSpawnPointsFunc = &mapGetSpawnPoints,
+  .ConsiderMobSpawnPointFunc = &mapConsiderMobSpawnPoint
 };
 
 //--------------------------------------------------------------------------
@@ -134,6 +142,13 @@ void mapOnMobKilled(Moby* moby, int killedByPlayerId, int killedByWeaponId)
 
 #if SOULCOLLECTOR
   soulcollectorOnSoul(moby->Position, killedByPlayerId);
+#endif
+
+#ifdef AMMO_DROP_PROBABILITY
+  Player* player = playerGetAll()[killedByPlayerId];
+  if (playerIsValid(player) && player->IsLocal && randRange(0, 1) < AMMO_DROP_PROBABILITY) {
+    ammodropCreateAt(moby);
+  }
 #endif
 }
 
@@ -564,14 +579,12 @@ void survivalInit(void)
     return;
 
   MapConfig.Magic = MAP_CONFIG_MAGIC;
-  MapConfig.ConsiderMobSpawnPointFunc = mapConsiderMobSpawnPoint;
-  MapConfig.GetSpawnPointsFunc = mapGetSpawnPoints;
-  MapConfig.OnMobCreateFunc = &createMob;
 
   mapApplyFixes();
   poolInit();
   mboxInit();
   mobInit();
+  ammosupplyInit();
   configInit();
   upgradeInit();
   dropInit();
@@ -589,6 +602,9 @@ void survivalInit(void)
 #endif
 #if RANDOMIZE_WEAPONS_AT_START
   randomizeWeaponPickups();
+#endif
+#ifdef AMMO_DROP_PROBABILITY
+  ammodropInit();
 #endif
 
   // disable jump pad effect

--- a/pvar_overlay.json
+++ b/pvar_overlay.json
@@ -5602,7 +5602,7 @@
     ]
   },
   {
-    "Name": "Raids Health Proxy",
+    "Name": "Health Proxy",
     "RCVersion": 4,
     "MobyOClass": 16397,
     "Length": 348,
@@ -5656,7 +5656,7 @@
         "Name": "Show Damage Popups",
         "DataType": "Bool",
         "DataSize": 1,
-        "Offset": 99
+        "Offset": 98
       },
       {
         "Name": "Target Moby",
@@ -5667,7 +5667,7 @@
         "Name": "Targetable",
         "DataType": "Bool",
         "DataSize": 1,
-        "Offset": 98,
+        "Offset": 97,
         "DisplayIf": [
           { "Field": "Team", "Op": "==", "Value": "1" }
         ]
@@ -5676,21 +5676,13 @@
         "Name": "Targeting Height",
         "DataType": "Float",
         "Offset": 88,
-        "Default": 1,
-        "DisplayIf": [
-          { "Field": "Team", "Op": "==", "Value": "1" },
-          { "Field": "Targetable", "Op": "==", "Value": "True" }
-        ]
+        "Default": 1
       },
       {
         "Name": "Targeting Radius",
         "DataType": "Float",
         "Offset": 92,
-        "Default": 1,
-        "DisplayIf": [
-          { "Field": "Team", "Op": "==", "Value": "1" },
-          { "Field": "Targetable", "Op": "==", "Value": "True" }
-        ]
+        "Default": 1
       },
       {
         "Name": "Healthbar",
@@ -5721,7 +5713,7 @@
         "Name": "Mob Aggro Type",
         "DataType": "Enum",
         "DataSize": 1,
-        "Offset": 97,
+        "Offset": 99,
         "Options": {
           "Ignore": 0,
           "When In Range": 1,
@@ -5758,11 +5750,11 @@
         "Offset": 120
       },
       {
-        "Name": "Values",
+        "Name": "Stats",
         "DataType": "Struct",
         "Offset": 124,
         "DataSize": 12,
-        "Count": 5,
+        "Count": 1,
         "Labels": [
           "1 Star",
           "2 Stars",
@@ -6035,6 +6027,142 @@
         "Name": "On Drop (Controller)",
         "DataType": "MobyRef",
         "Offset": 92
+      }
+    ]
+  },
+  {
+    "Name": "Ammo Supply",
+    "RCVersion": 4,
+    "MobyOClass": 511,
+    "Length": 64,
+    "Overlay": [
+      {
+        "Name": "Dual Vipers Cost",
+        "DataType": "Integer",
+        "Offset": 0,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 20
+      },
+      {
+        "Name": "Dual Raptors Cost",
+        "DataType": "Integer",
+        "Offset": 32,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 100
+      },
+      {
+        "Name": "Magma Cannon Cost",
+        "DataType": "Integer",
+        "Offset": 4,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 50
+      },
+      {
+        "Name": "Vulcan Cannon Cost",
+        "DataType": "Integer",
+        "Offset": 36,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 200
+      },
+      {
+        "Name": "Arbiter Cost",
+        "DataType": "Integer",
+        "Offset": 8,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 100
+      },
+      {
+        "Name": "Silencer Cost",
+        "DataType": "Integer",
+        "Offset": 40,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 250
+      },
+      {
+        "Name": "Fusion Rifle Cost",
+        "DataType": "Integer",
+        "Offset": 12,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 100
+      },
+      {
+        "Name": "Anti-Matter Rifle Cost",
+        "DataType": "Integer",
+        "Offset": 44,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 250
+      },
+      {
+        "Name": "Hunter Mine Launcher Cost",
+        "DataType": "Integer",
+        "Offset": 16,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 100
+      },
+      {
+        "Name": "Stalker Mine Launcher Cost",
+        "DataType": "Integer",
+        "Offset": 48,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 250
+      },
+      {
+        "Name": "B6 Obliterator Cost",
+        "DataType": "Integer",
+        "Offset": 20,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 100
+      },
+      {
+        "Name": "B11 Vaporizer Cost",
+        "DataType": "Integer",
+        "Offset": 52,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 250
+      },
+      {
+        "Name": "Scorpion Flail Cost",
+        "DataType": "Integer",
+        "Offset": 24,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 50
+      },
+      {
+        "Name": "Leviathan Flail Cost",
+        "DataType": "Integer",
+        "Offset": 56,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 200
+      },
+      {
+        "Name": "Holoshield Cost",
+        "DataType": "Integer",
+        "Offset": 28,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 50
+      },
+      {
+        "Name": "Omnishield Cost",
+        "DataType": "Integer",
+        "Offset": 60,
+        "Min": 0,
+        "Max": 100000000,
+        "Default": 200
       }
     ]
   }


### PR DESCRIPTION
- Add WIP survival mob targeting rules. Original behavior is functions as the default, and new mob pvar field for `targetingRule` is allocated. The logic for the other rules may be completed at a future date without issue.
- Add ammo drop moby to survival
- Add ammo supply vendor moby to survival