### PR TITLE
Survival: Migrate baked config to overridable getter functions

### DIFF
--- a/Assets/Forge/Scripts/CustomMode/SurvivalModeData.cs
+++ b/Assets/Forge/Scripts/CustomMode/SurvivalModeData.cs
@@ -16,6 +16,8 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
     public const int BANK_OCLASS = 0x1F7;
     public const int STACKBOX_OCLASS = 0x2083;
     public const int SURVIVAL_MAX_SPAWNED_MOBS = 50;
+    static readonly uint[] DEFAULT_PRESTIGE_COSTS = { 100000, 300000, 500000, 700000, 1000000 };
+    static readonly uint[] DEFAULT_VENDOR_COSTS = { 8000, 12000, 20000, 40000, 60000, 90000, 150000, 220000, 350000 };
 
     public override DLCustomModeIds CustomMode => DLCustomModeIds.Survival;
     public override bool IsEnabled => Enabled && this.isActiveAndEnabled;
@@ -81,10 +83,14 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
 	
 	[Header("Prestige")]
 	[Range(1, 5)] public int WeaponPrestigeMax = 5;
-	public List<int> PrestigeCostPerLevel = new List<int>() {100000, 300000, 500000, 700000, 1000000};
+    public List<uint> PrestigeCostPerLevel = new List<uint>(DEFAULT_PRESTIGE_COSTS);
+
+    [Header("Vendor")]
+    public List<uint> VendorCostPerLevel = new List<uint>(DEFAULT_VENDOR_COSTS);
 
     [Header("Wall Upgrades")]
-    public List<SurvivalUpgradeEntry> Upgrades = new List<SurvivalUpgradeEntry>() {
+    public List<SurvivalUpgradeEntry> Upgrades = new List<SurvivalUpgradeEntry>()
+    {
         new SurvivalUpgradeEntry() { Type = SurvivalUpgradeId.Health, Max = 2000 },
         new SurvivalUpgradeEntry() { Type = SurvivalUpgradeId.Damage, Max = 2000 },
         new SurvivalUpgradeEntry() { Type = SurvivalUpgradeId.Crit, Max = 100 },
@@ -115,18 +121,7 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
         }
 		
 		WeaponPrestigeMax = Mathf.Clamp(WeaponPrestigeMax, 1, 5);
-        while (PrestigeCostPerLevel.Count < WeaponPrestigeMax) {
-			int boltValue;
-			switch (PrestigeCostPerLevel.Count)
-			{
-				case 0: boltValue = 100000; break;
-				case 1: boltValue = 300000; break;
-				case 2: boltValue = 500000; break;
-				case 3: boltValue = 700000; break;
-				default: boltValue = 1000000; break;
-			}
-			PrestigeCostPerLevel.Add(boltValue);
-		}
+        while (PrestigeCostPerLevel.Count < WeaponPrestigeMax) PrestigeCostPerLevel.Add(DEFAULT_PRESTIGE_COSTS[PrestigeCostPerLevel.Count]);
         while (PrestigeCostPerLevel.Count > WeaponPrestigeMax) PrestigeCostPerLevel.RemoveAt(PrestigeCostPerLevel.Count - 1);
 
         foreach (var u in Upgrades)
@@ -186,6 +181,7 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/config.o");
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/survival.o");
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/path.o");
+        state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/interop.o");
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/gambits.o");
 
         state.ObjectFiles.Add($"{FolderNames.CodeBuildSrcFolder}/ammodrop.o");
@@ -372,6 +368,7 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
         var upgradeSpawns = HierarchicalSorting.Sort(FindObjectsOfType<SurvivalUpgradeSpawn>(false));
 
         sb.AppendLine("#include <libdl/utils.h>");
+        sb.AppendLine("#include \"config.h\"");
         sb.AppendLine("#include \"game.h\"");
         sb.AppendLine("#include \"upgrade.h\"");
         sb.AppendLine("#include \"mob.h\"");
@@ -409,16 +406,20 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
         sb.AppendLine($"\t.Difficulty = {Difficulty.ToInvariantCulture()},");
         sb.AppendLine($"\t.BoltMultiplier = {BoltMultiplier.ToInvariantCulture()},");
         sb.AppendLine($"\t.XpMultiplier = {XpMultiplier.ToInvariantCulture()},");
-        sb.AppendLine($"\t.SpawnDistanceFactor = {SpawnDistanceFactor.ToInvariantCulture()},");
+        sb.AppendLine($"\t.SpawnDistanceMultiplier = {SpawnDistanceFactor.ToInvariantCulture()},");
+        sb.AppendLine($"\t.WeaponPickupCooldownMultiplier = {WeaponPickupCooldownFactor.ToInvariantCulture()},");
         sb.AppendLine($"\t.BoltRankMultiplier = {BoltRankMultiplier.ToInvariantCulture()},");
         sb.AppendLine($"\t.StackboxBaseCost = {StackableBaseCost},");
         sb.AppendLine($"\t.StackboxCostPerPerk = {StackableIncrementCost},");
-		
-		sb.AppendLine($"\t.WeaponPrestigeMax = {WeaponPrestigeMax},");
+        sb.AppendLine($"\t.WeaponPrestigeMax = {WeaponPrestigeMax},");
 		sb.AppendLine("\t.PrestigeCostPerLevel = {");
 		foreach(var cost in PrestigeCostPerLevel)
 			sb.AppendLine($"\t\t{cost},");
-		sb.AppendLine("\t},");
+        sb.AppendLine("\t},");
+        sb.AppendLine("\t.VendorCost = {");
+        foreach (var cost in VendorCostPerLevel)
+            sb.AppendLine($"\t\t{cost},");
+        sb.AppendLine("\t},");
 		
         sb.AppendLine("\t.BakedSpawnPoints = {");
         foreach (var item in upgradeSpawns)
@@ -479,7 +480,6 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
         sb.AppendLine("\tMapConfig.SpecialRoundParamsCount = COUNT_OF(specialRoundParams);");
 		sb.AppendLine("\tMapConfig.UpgradeDefs = upgradeDefs;");
         sb.AppendLine("\tMapConfig.UpgradeDefCount = COUNT_OF(upgradeDefs);");
-        sb.AppendLine($"\tMapConfig.WeaponPickupCooldownFactor = {WeaponPickupCooldownFactor.ToInvariantCulture()};");
         sb.AppendLine("}");
         sb.AppendLine();
 
@@ -1562,10 +1562,10 @@ public enum SurvivalStackableItemId
 
 public enum SurvivalUpgradeId
 {
-	Health = 0,
-	Speed = 1,
-	Damage = 2,
- 	Crit = 6
+	Health,
+	Speed,
+	Damage,
+ 	Crit
 };
 
 public enum SurvivalMobStatIds

--- a/codegen/rc4/base/main.c
+++ b/codegen/rc4/base/main.c
@@ -49,7 +49,14 @@ struct Guber* mapGetGuber(Moby* moby)
 ##GETGUBERCASES##
     default:
     {
-      #if RAIDS || SURVIVAL
+      #if SURVIVAL
+        if (MapConfig.Functions.ModeOnGetGuberFunc) {
+          struct Guber* guber = MapConfig.Functions.ModeOnGetGuberFunc(moby);
+          if (guber) return guber;
+        }
+      #endif
+    
+      #if RAIDS
         if (MapConfig.OnGetGuberFunc) {
           struct Guber* guber = MapConfig.OnGetGuberFunc(moby);
           if (guber) return guber;
@@ -84,7 +91,14 @@ void mapHandleEvent(Moby* moby, GuberEvent* event)
   ##HANDLEEVENTCASES##
       default:
 			{
-        #if RAIDS || SURVIVAL
+        #if SURVIVAL
+          if (MapConfig.Functions.ModeOnGuberEventFunc) {
+            MapConfig.Functions.ModeOnGuberEventFunc(moby, event);
+            return;
+          }
+        #endif
+      
+        #if RAIDS
           if (MapConfig.OnGuberEventFunc) {
             MapConfig.OnGuberEventFunc(moby, event);
             return;

--- a/codegen/rc4/common/dummy.c
+++ b/codegen/rc4/common/dummy.c
@@ -283,8 +283,17 @@ void dummyUpdate(Moby* moby)
       }
 
       // bubble
-      //if (pvars->Config.DamageBubbles && MapConfig.PushDamageBubbleFunc)
-      //  MapConfig.PushDamageBubbleFunc(moby->Position, pvars->Config.TargetRadius, damage, 0, 0);
+#if SURVIVAL
+      // if friendly, show as green damage
+      // otherwise use crit/noncrit team colors
+      int team = TEAM_GREEN;
+      if (pvars->Config.IsOnEnemyTeam)
+        team = (damageFlags & 0x20000000) ? TEAM_RED : TEAM_YELLOW;
+
+      // push bubble
+      if (pvars->Config.DamageBubbles && MapConfig.Functions.ModePushBubbleFunc)
+        MapConfig.Functions.ModePushBubbleFunc(moby->Position, pvars->Config.TargetRadius, damage, 0, pvars->Config.IsOnEnemyTeam ? TEAM_YELLOW : TEAM_GREEN);
+#endif
 
       pvars->State.TicksSinceLastDamage = 0;
     }

--- a/codegen/rc4/common/maputils.c
+++ b/codegen/rc4/common/maputils.c
@@ -192,8 +192,8 @@ u32 decTimerU32(u32* timeValue)
 void pushSnack(int localPlayerIdx, char* string, int ticksAlive)
 {
 #if SURVIVAL
-  if (MapConfig.PushSnackFunc)
-    MapConfig.PushSnackFunc(string, ticksAlive, localPlayerIdx);
+  if (MapConfig.Functions.ModePushSnackFunc)
+    MapConfig.Functions.ModePushSnackFunc(string, ticksAlive, localPlayerIdx);
   else
     uiShowPopup(localPlayerIdx, string);
 #else

--- a/codegen/rc4/survival/config.h
+++ b/codegen/rc4/survival/config.h
@@ -1,0 +1,52 @@
+#ifndef SURVIVAL_CONFIG_H
+#define SURVIVAL_CONFIG_H
+
+#define BAKED_SPAWNPOINT_COUNT							  (32)
+#define WEAPON_PRESTIGE_MAX                   (5)
+#define VENDOR_MAX_WEAPON_LEVEL								(9)
+
+#include <tamtypes.h>
+#include <libdl/moby.h>
+#include <libdl/math.h>
+#include <libdl/time.h>
+#include <libdl/player.h>
+#include <libdl/math3d.h>
+#include "game.h"
+
+enum BakedSpawnpointType
+{
+	BAKED_SPAWNPOINT_NONE = 0,
+	BAKED_SPAWNPOINT_UPGRADE = 1,
+};
+
+typedef struct SurvivalBakedSpawnpoint
+{
+	enum BakedSpawnpointType Type;
+	int Params;
+	float Position[3];
+	float Rotation[3];
+} SurvivalBakedSpawnpoint_t;
+
+typedef struct SurvivalBakedConfig
+{
+	float Difficulty;
+	float BoltMultiplier;
+	float XpMultiplier;
+	float SpawnDistanceMultiplier;
+	float WeaponPickupCooldownMultiplier;
+	int BoltRankMultiplier;
+	SurvivalBakedSpawnpoint_t BakedSpawnPoints[BAKED_SPAWNPOINT_COUNT];
+	int StackboxBaseCost;
+	int StackboxCostPerPerk;
+	char WeaponPrestigeMax;
+	int PrestigeCostPerLevel[WEAPON_PRESTIGE_MAX];
+	u32 VendorCost[VENDOR_MAX_WEAPON_LEVEL];
+} SurvivalBakedConfig_t;
+
+extern int mobAllowedCuboidIdx;
+extern int mobSpawnPointsAreaIdx;
+extern SurvivalBakedConfig_t bakedConfig;
+
+void configInit(void);
+
+#endif // SURVIVAL_CONFIG_H

--- a/codegen/rc4/survival/drop.c
+++ b/codegen/rc4/survival/drop.c
@@ -325,8 +325,8 @@ int dropHandleEvent_Pickup(Moby* moby, GuberEvent* event)
 					if (!playerIsDead(p) && p->Health > 0) {
 						playerSetHealth(p, p->MaxHealth);
 					}
-					else if (MapConfig.ModeRevivePlayerFunc && MapConfig.State && MapConfig.State->PlayerStates[i].ReviveCooldownTicks) {
-			      MapConfig.ModeRevivePlayerFunc(p, args.PickedUpByPlayerId);
+					else if (MapConfig.Functions.ModeRevivePlayerFunc && MapConfig.State && MapConfig.State->PlayerStates[i].ReviveCooldownTicks) {
+			      MapConfig.Functions.ModeRevivePlayerFunc(p, args.PickedUpByPlayerId);
 					}
 
 					if (p->IsLocal)
@@ -340,7 +340,7 @@ int dropHandleEvent_Pickup(Moby* moby, GuberEvent* event)
 			DPRINTF("giving double bolts to all players\n");
 			uiShowPopup(0, "Double bolts!");
 			uiShowPopup(1, "Double bolts!");
-			if (MapConfig.ModeSetDoublePointsFunc) MapConfig.ModeSetDoublePointsFunc(1);
+			if (MapConfig.Functions.ModeSetDoublePointsFunc) MapConfig.Functions.ModeSetDoublePointsFunc(1);
 			break;
 		}
 		case DROP_DOUBLE_XP:
@@ -348,7 +348,7 @@ int dropHandleEvent_Pickup(Moby* moby, GuberEvent* event)
 			DPRINTF("giving double xp to all players\n");
 			uiShowPopup(0, "Double XP!");
 			uiShowPopup(1, "Double XP!");
-			if (MapConfig.ModeSetDoubleXPFunc) MapConfig.ModeSetDoubleXPFunc(1);
+			if (MapConfig.Functions.ModeSetDoubleXPFunc) MapConfig.Functions.ModeSetDoubleXPFunc(1);
 			break;
 		}
 		case DROP_FREEZE:
@@ -356,7 +356,7 @@ int dropHandleEvent_Pickup(Moby* moby, GuberEvent* event)
 			DPRINTF("freezing all mobs\n");
 			uiShowPopup(0, "Freeze activated!");
 			uiShowPopup(1, "Freeze activated!");
-			if (MapConfig.ModeSetFreezeMobsFunc) MapConfig.ModeSetFreezeMobsFunc(1);
+			if (MapConfig.Functions.ModeSetFreezeMobsFunc) MapConfig.Functions.ModeSetFreezeMobsFunc(1);
 			break;
 		}
 		case DROP_NUKE:
@@ -364,7 +364,7 @@ int dropHandleEvent_Pickup(Moby* moby, GuberEvent* event)
 			DPRINTF("killing all mobs\n");
 			uiShowPopup(0, "Nuke activated!");
 			uiShowPopup(1, "Nuke activated!");
-			if (MapConfig.ModeMobNukeFunc) MapConfig.ModeMobNukeFunc(args.PickedUpByPlayerId);
+			if (MapConfig.Functions.ModeMobNukeFunc) MapConfig.Functions.ModeMobNukeFunc(args.PickedUpByPlayerId);
 			break;
 		}
 	}
@@ -474,8 +474,7 @@ void dropInit(void)
   }
   mobyDestroy(temp);
 
-  MapConfig.CreateMobDropFunc = &dropCreate;
-  MapConfig.OnMobDropEventFunc = &dropHandleEvent;
+  MapConfig.Functions.CreateMobDropFunc = &dropCreate;
 }
 
 //--------------------------------------------------------------------------

--- a/codegen/rc4/survival/gambits.c
+++ b/codegen/rc4/survival/gambits.c
@@ -217,7 +217,7 @@ void gambitsSetup(void)
   gambitsSetupInitialBoltsTokens(gambit->InitialBolts, gambit->InitialTokens);
   if (gambit->CustomInit) gambit->CustomInit();
 
-  MapConfig.CreateMobDropFunc = &gambitsDropCreate;
+  MapConfig.Functions.CreateMobDropFunc = &gambitsDropCreate;
   GambitsState.FinishedSetup = 1;
 }
 

--- a/codegen/rc4/survival/game.h
+++ b/codegen/rc4/survival/game.h
@@ -2,9 +2,11 @@
 #define SURVIVAL_GAME_H
 
 #include <tamtypes.h>
-#include "messageid.h"
 #include <libdl/player.h>
 #include <libdl/math3d.h>
+#include "messageid.h"
+#include "config.h"
+#include "interop.h"
 #include "upgrade.h"
 #include "drop.h"
 #include "gate.h"
@@ -14,625 +16,425 @@
 #include "demonbell.h"
 #include "utils.h"
 
-#define MAP_CONFIG_MAGIC                      (0xDEADBEEF)
+#define MAP_CONFIG_MAGIC (0xDEADBEEF)
 
-#define TPS																		(60)
+#define TPS (60)
 
-#define ZOMBIE_MOBY_OCLASS										(0x20F6)
-#define EXECUTIONER_MOBY_OCLASS							  (0x20A1)
-#define TREMOR_MOBY_OCLASS							      (0x24D3)
-#define SWARMER_MOBY_OCLASS							      (0x2695)
-#define SWARMER2_MOBY_OCLASS							    (0x2051)
-#define REAPER_MOBY_OCLASS							      (0x2570)
-#define REACTOR_MOBY_OCLASS							      (0x20BE)
-#define LEVIATHAN_MOBY_OCLASS							    (0x20C4)
+#define ZOMBIE_MOBY_OCLASS (0x20F6)
+#define EXECUTIONER_MOBY_OCLASS (0x20A1)
+#define TREMOR_MOBY_OCLASS (0x24D3)
+#define SWARMER_MOBY_OCLASS (0x2695)
+#define SWARMER2_MOBY_OCLASS (0x2051)
+#define REAPER_MOBY_OCLASS (0x2570)
+#define REACTOR_MOBY_OCLASS (0x20BE)
+#define LEVIATHAN_MOBY_OCLASS (0x20C4)
 
-#define STATUE_MOBY_OCLASS                    (0x2402)
-#define BIGAL_MOBY_OCLASS                     (0x2124)
-#define VENDOR_MOBY_OCLASS                    (0x263A)
+#define STATUE_MOBY_OCLASS (0x2402)
+#define BIGAL_MOBY_OCLASS (0x2124)
+#define VENDOR_MOBY_OCLASS (0x263A)
 
-#define GRAVITY_MAGNITUDE                     (15 * MATH_DT)
+#define GRAVITY_MAGNITUDE (15 * MATH_DT)
 
-#define MOBS_PLAY_SOUND_COOLDOWN              (10)
+#define MOBS_PLAY_SOUND_COOLDOWN (10)
 #define MOBS_PLAY_SOUND_COOLDOWN_MAX_SOUNDIDS (20)
 
-#define MAX_MOBS_BASE													(10)
-//#define MAX_MOBS_ROUND_WEIGHT									(10)
-#define MAX_MOBS_ALIVE											  (60)
-#define MAX_MOBS_ALIVE_BUFFER									(10)
-#define MAX_MOBS_ALIVE_REAL									  (MAX_MOBS_ALIVE - MAX_MOBS_ALIVE_BUFFER)
+#define MAX_MOBS_BASE (10)
+// #define MAX_MOBS_ROUND_WEIGHT									(10)
+#define MAX_MOBS_ALIVE (60)
+#define MAX_MOBS_ALIVE_BUFFER (10)
+#define MAX_MOBS_ALIVE_REAL (MAX_MOBS_ALIVE - MAX_MOBS_ALIVE_BUFFER)
 
 #ifndef MAX_MOBS_ROUND_WEIGHT
 #define MAX_MOBS_ROUND_WEIGHT 10
 #endif
 
-#define ROUND_MESSAGE_DURATION_MS							(TIME_SECOND * 2)
-#define ROUND_START_DELAY_MS									(TIME_SECOND * 1)
+#define ROUND_MESSAGE_DURATION_MS (TIME_SECOND * 2)
+#define ROUND_START_DELAY_MS (TIME_SECOND * 1)
 
 #if QUICK_SPAWN
-#define ROUND_TRANSITION_DELAY_MS							(TIME_SECOND * 0)
+#define ROUND_TRANSITION_DELAY_MS (TIME_SECOND * 0)
 #else
-#define ROUND_TRANSITION_DELAY_MS							(TIME_SECOND * 45)
+#define ROUND_TRANSITION_DELAY_MS (TIME_SECOND * 45)
 #endif
 
-#define ROUND_BASE_BOLT_BONUS									(100)
-#define ROUND_MAX_BOLT_BONUS									(10000)
+#define ROUND_BASE_BOLT_BONUS (100)
+#define ROUND_MAX_BOLT_BONUS (10000)
 
-#define ROUND_SPECIAL_BONUS_MULTIPLIER				(5)
+#define ROUND_SPECIAL_BONUS_MULTIPLIER (5)
 
-#define MOB_TARGET_DIST_IN_SIGHT_IGNORE_PATH 	(100)
-#define MOB_MOVE_SKIP_TICKS                   (8)
-#define MOB_MOVE_SKIP_TICKS_LOWPRIORITY       (16)
-#define MOB_MAX_STUCK_COUNTER_FOR_NEW_PATH    (5)
+#define MOB_TARGET_DIST_IN_SIGHT_IGNORE_PATH (100)
+#define MOB_MOVE_SKIP_TICKS (8)
+#define MOB_MOVE_SKIP_TICKS_LOWPRIORITY (16)
+#define MOB_MAX_STUCK_COUNTER_FOR_NEW_PATH (5)
 
-#define MOB_SHORT_FREEZE_DURATION_TICKS       (60)
-#define MOB_SHORT_FREEZE_SPEED_FACTOR         (0.15)
+#define MOB_SHORT_FREEZE_DURATION_TICKS (60)
+#define MOB_SHORT_FREEZE_SPEED_FACTOR (0.15)
 
-#define MOB_SPAWN_SEMI_NEAR_PLAYER_PROBABILITY 		(1)
-#define MOB_SPAWN_NEAR_PLAYER_PROBABILITY 				(0.25)
-#define MOB_SPAWN_AT_PLAYER_PROBABILITY 					(0.01)
-#define MOB_SPAWN_NEAR_HEALTHBOX_PROBABILITY 			(0.1)
+#define MOB_SPAWN_SEMI_NEAR_PLAYER_PROBABILITY (1)
+#define MOB_SPAWN_NEAR_PLAYER_PROBABILITY (0.25)
+#define MOB_SPAWN_AT_PLAYER_PROBABILITY (0.01)
+#define MOB_SPAWN_NEAR_HEALTHBOX_PROBABILITY (0.1)
 
-#define MOB_SPAWN_BURST_MIN_DELAY							(1 * 60)
-#define MOB_SPAWN_BURST_MAX_DELAY							(10 * 60)
-#define MOB_SPAWN_BURST_MIN										(3)
-#define MOB_SPAWN_BURST_MAX										(10)
-#define MOB_SPAWN_BURST_MAX_INC_PER_ROUND			(1)
-#define MOB_SPAWN_BURST_MIN_INC_PER_ROUND			(0)
+#define MOB_SPAWN_BURST_MIN_DELAY (1 * 60)
+#define MOB_SPAWN_BURST_MAX_DELAY (10 * 60)
+#define MOB_SPAWN_BURST_MIN (3)
+#define MOB_SPAWN_BURST_MAX (10)
+#define MOB_SPAWN_BURST_MAX_INC_PER_ROUND (1)
+#define MOB_SPAWN_BURST_MIN_INC_PER_ROUND (0)
 
-#define MOB_AUTO_DIRTY_COOLDOWN_TICKS			    (60 * 5)
+#define MOB_AUTO_DIRTY_COOLDOWN_TICKS (60 * 5)
 
-#define MOB_BASE_DAMAGE										    (10)
-#define MOB_BASE_DAMAGE_SCALE                 (0.03*1)
-#define MOB_BASE_SPEED											  (3)
-#define MOB_BASE_SPEED_SCALE                  (0.05*1)
-#define MOB_BASE_HEALTH										    (30)
-#define MOB_BASE_HEALTH_SCALE                 (0.05*1)
-#define MOB_JUMP_MOVE_SPEED                   (10)
+#define MOB_BASE_DAMAGE (10)
+#define MOB_BASE_DAMAGE_SCALE (0.03 * 1)
+#define MOB_BASE_SPEED (3)
+#define MOB_BASE_SPEED_SCALE (0.05 * 1)
+#define MOB_BASE_HEALTH (30)
+#define MOB_BASE_HEALTH_SCALE (0.05 * 1)
+#define MOB_JUMP_MOVE_SPEED (10)
 
-#define MOB_SPECIAL_MUTATION_PROBABILITY		  (0.005)
-#define MOB_SPECIAL_MUTATION_BASE_COST			  (200)
-#define MOB_SPECIAL_MUTATION_REL_COST			    (1.0)
+#define MOB_SPECIAL_MUTATION_PROBABILITY (0.005)
+#define MOB_SPECIAL_MUTATION_BASE_COST (200)
+#define MOB_SPECIAL_MUTATION_REL_COST (1.0)
 
 #if PAYDAY
-#define MOB_BASE_BOLTS											  (1000000)
+#define MOB_BASE_BOLTS (1000000)
 #else
-#define MOB_BASE_BOLTS											  (220)
+#define MOB_BASE_BOLTS (220)
 #endif
 
-#define JACKPOT_BOLTS													(50)
-#define XP_ALPHAMOD_XP												(10)
+#define JACKPOT_BOLTS (50)
+#define XP_ALPHAMOD_XP (10)
 
-#define DROP_COOLDOWN_TICKS_MIN								(TPS * 10)
-#define DROP_COOLDOWN_TICKS_MAX								(TPS * 60)
-#define DROP_DURATION													(30 * TIME_SECOND)
-#define DOUBLE_POINTS_DURATION								(20 * TIME_SECOND)
-#define DOUBLE_XP_DURATION								    (20 * TIME_SECOND)
-#define FREEZE_DROP_DURATION									(10 * TIME_SECOND)
-#define MOB_HAS_DROP_PROBABILITY						  (0.01)
-#define MOB_HAS_DROP_PROBABILITY_LUCKY			  (0.05)
-#define DROP_MAX_SPAWNED											(4)
+#define DROP_COOLDOWN_TICKS_MIN (TPS * 10)
+#define DROP_COOLDOWN_TICKS_MAX (TPS * 60)
+#define DROP_DURATION (30 * TIME_SECOND)
+#define DOUBLE_POINTS_DURATION (20 * TIME_SECOND)
+#define DOUBLE_XP_DURATION (20 * TIME_SECOND)
+#define FREEZE_DROP_DURATION (10 * TIME_SECOND)
+#define MOB_HAS_DROP_PROBABILITY (0.01)
+#define MOB_HAS_DROP_PROBABILITY_LUCKY (0.05)
+#define DROP_MAX_SPAWNED (4)
 
-#define PLAYER_BASE_REVIVE_TICKS					    (60 * TPS)
-#define PLAYER_MIN_REVIVE_TICKS					      (10 * TPS)
-#define PLAYER_REVIVE_COST_PER_REVIVE_TICKS		(10 * TPS)
-#define PLAYER_TIME_TO_REVIVE_TICKS		        (5 * TPS)
-#define PLAYER_REVIVE_MAX_DIST								(2.5)
-#define PLAYER_REVIVE_COOLDOWN_TICKS					(120)
-#define PLAYER_KNOCKBACK_BASE_POWER						(3.0)
-#define PLAYER_KNOCKBACK_BASE_TICKS						(10)
-#define PLAYER_COLL_RADIUS          					(0.5)
-#define PLAYER_MAX_BLESSINGS                  (4)
+#define PLAYER_BASE_REVIVE_TICKS (60 * TPS)
+#define PLAYER_MIN_REVIVE_TICKS (10 * TPS)
+#define PLAYER_REVIVE_COST_PER_REVIVE_TICKS (10 * TPS)
+#define PLAYER_TIME_TO_REVIVE_TICKS (5 * TPS)
+#define PLAYER_REVIVE_MAX_DIST (2.5)
+#define PLAYER_REVIVE_COOLDOWN_TICKS (120)
+#define PLAYER_KNOCKBACK_BASE_POWER (3.0)
+#define PLAYER_KNOCKBACK_BASE_TICKS (10)
+#define PLAYER_COLL_RADIUS (0.5)
+#define PLAYER_MAX_BLESSINGS (4)
+#define PLAYER_RESPAWN_INV_TICKS (TPS * 2)
 
-#define BIG_AL_MAX_DIST												(5)
-#define WEAPON_VENDOR_MAX_DIST								(3)
-#define WEAPON_UPGRADE_COOLDOWN_TICKS					(15)
-#define WEAPON_MENU_COOLDOWN_TICKS						(60)
-#define VENDOR_MAX_WEAPON_LEVEL								(9)
+#define BIG_AL_MAX_DIST (5)
+#define WEAPON_VENDOR_MAX_DIST (3)
+#define WEAPON_UPGRADE_COOLDOWN_TICKS (15)
+#define WEAPON_MENU_COOLDOWN_TICKS (60)
 
-#define PRESTIGE_MACHINE_MAX_DIST			  (5)
-#define WEAPON_PRESTIGE_MAX                   (5)
+#define PRESTIGE_MACHINE_MAX_DIST (5)
 
-#define PLAYER_UPGRADE_DAMAGE_FACTOR          (0.08)
-#define PLAYER_UPGRADE_SPEED_FACTOR           (0.03)
-#define PLAYER_UPGRADE_HEALTH_FACTOR          (5)
-#define PLAYER_UPGRADE_CRIT_FACTOR            (0.01)
+#define PLAYER_UPGRADE_DAMAGE_FACTOR (0.08)
+#define PLAYER_UPGRADE_SPEED_FACTOR (0.03)
+#define PLAYER_UPGRADE_HEALTH_FACTOR (5)
+#define PLAYER_UPGRADE_CRIT_FACTOR (0.01)
 
-#define BAKED_SPAWNPOINT_COUNT							  (32)
+#define ITEM_INVISCLOAK_DURATION (30 * TIME_SECOND)
+#define ITEM_INFAMMO_DURATION (30 * TIME_SECOND)
+#define ITEM_QUAD_DURATION_TPS (1 * 60 * TPS)
+#define ITEM_SHIELD_DURATION_TPS (1 * 60 * TPS)
+#define ITEM_EMP_HEALTH_EFFECT_RADIUS (15)
+#define ITEM_HEALTHTORNADO_DURATION (10 * TIME_SECOND)
+#define ITEM_HEALTHTORNADO_PERIOD_TICKS (TPS * 0.25)
+#define ITEM_HEALTHTORNADO_HEAL_PERCENT (0.05)
 
-#define ITEM_INVISCLOAK_DURATION              (30*TIME_SECOND)
-#define ITEM_INFAMMO_DURATION                 (30*TIME_SECOND)
-#define ITEM_QUAD_DURATION_TPS                (1*60*TPS)
-#define ITEM_SHIELD_DURATION_TPS              (1*60*TPS)
-#define ITEM_EMP_HEALTH_EFFECT_RADIUS         (15)
-#define ITEM_HEALTHTORNADO_DURATION           (10*TIME_SECOND)
-#define ITEM_HEALTHTORNADO_PERIOD_TICKS       (TPS * 0.25)
-#define ITEM_HEALTHTORNADO_HEAL_PERCENT       (0.05)
+#define ITEM_BLESSING_HEALTH_REGEN_RATE_TPS (TPS * 0.2)
+#define ITEM_BLESSING_AMMO_REGEN_RATE_TPS (TPS * 5)
+#define ITEM_BLESSING_THORN_DAMAGE_FACTOR (0.2)
+#define ITEM_BLESSING_MULTI_JUMP_COUNT (5)
 
-#define ITEM_BLESSING_HEALTH_REGEN_RATE_TPS   (TPS * 0.2)
-#define ITEM_BLESSING_AMMO_REGEN_RATE_TPS     (TPS * 5)
-#define ITEM_BLESSING_THORN_DAMAGE_FACTOR     (0.2)
-#define ITEM_BLESSING_MULTI_JUMP_COUNT        (5)
-
-#define ITEM_STACKABLE_HOVERBOOTS_DUR_TPS     (2 * TPS)
-#define ITEM_STACKABLE_HOVERBOOTS_SPEED_BUF   (0.1)
+#define ITEM_STACKABLE_HOVERBOOTS_DUR_TPS (2 * TPS)
+#define ITEM_STACKABLE_HOVERBOOTS_SPEED_BUF (0.1)
 #define ITEM_STACKABLE_LOW_HEALTH_DMG_BUF_FAC (0.75)
 #define ITEM_STACKABLE_LOW_HEALTH_DMG_BUF_RAMP (0.5)
-#define ITEM_STACKABLE_ALPHA_MOD_AMT          (2)
-#define ITEM_STACKABLE_VAMPIRE_HEALTH_AMT     (3)
-#define ITEM_STACKABLE_EXPLODINGENEMIES_DAMAGE          (20)
-#define ITEM_STACKABLE_EXPLODINGENEMIES_RADIUS          (5.0)
+#define ITEM_STACKABLE_ALPHA_MOD_AMT (2)
+#define ITEM_STACKABLE_VAMPIRE_HEALTH_AMT (3)
+#define ITEM_STACKABLE_EXPLODINGENEMIES_DAMAGE (20)
+#define ITEM_STACKABLE_EXPLODINGENEMIES_RADIUS (5.0)
 
+#define SNACK_ITEM_MAX_COUNT (8)
+#define DAMAGE_BUBBLE_MAX_COUNT (16)
 
-#define SNACK_ITEM_MAX_COUNT                  (8)
-#define DAMAGE_BUBBLE_MAX_COUNT               (16)
+#define MAX_MOB_SPAWN_PARAMS (16)
+#define MAX_MOB_COMPLEXITY_DRAWN (7500)
+#define MAX_MOB_COMPLEXITY_DRAWN_DZO (MAX_MOB_COMPLEXITY_DRAWN * 1)
+#define MOB_COMPLEXITY_SKIN_FACTOR (500)
+#define MAX_MOB_COMPLEXITY_MIN (1000)
+#define MOB_COMPLEXITY_LOD_FACTOR (500)
+#define MOB_MAX_FLINCH_PROBABILITY (0.25)
+#define MOB_FORCED_BLIP_COOLDOWN_TICKS (TPS * 5)
 
-#define MAX_MOB_SPAWN_PARAMS                  (16)
-#define MAX_MOB_COMPLEXITY_DRAWN              (7500)
-#define MAX_MOB_COMPLEXITY_DRAWN_DZO          (MAX_MOB_COMPLEXITY_DRAWN * 1)
-#define MOB_COMPLEXITY_SKIN_FACTOR            (500)
-#define MAX_MOB_COMPLEXITY_MIN                (1000)
-#define MOB_COMPLEXITY_LOD_FACTOR             (500)
-#define MOB_MAX_FLINCH_PROBABILITY            (0.25)
-#define MOB_FORCED_BLIP_COOLDOWN_TICKS        (TPS * 5)
-
-#define SWARMER_RENDER_COST                   (40)
-#define ZOMBIE_RENDER_COST                    (85)
-#define TREMOR_RENDER_COST                    (150)
-#define REAPER_RENDER_COST                    (150)
-#define REACTOR_RENDER_COST                   (300)
-#define EXECUTIONER_RENDER_COST               (300)
-#define LEVIATHAN_RENDER_COST                 (300)
+#define SWARMER_RENDER_COST (40)
+#define ZOMBIE_RENDER_COST (85)
+#define TREMOR_RENDER_COST (150)
+#define REAPER_RENDER_COST (150)
+#define REACTOR_RENDER_COST (300)
+#define EXECUTIONER_RENDER_COST (300)
+#define LEVIATHAN_RENDER_COST (300)
 
 enum GameNetMessage
 {
-  CUSTOM_MSG_ROUND_COMPLETE = CUSTOM_MSG_ID_GAME_MODE_START,
-  CUSTOM_MSG_ROUND_START,
-  CUSTOM_MSG_UPDATE_SPAWN_VARS,
-  CUSTOM_MSG_WEAPON_UPGRADE,
-  CUSTOM_MSG_REVIVE_PLAYER,
-  CUSTOM_MSG_PLAYER_DIED,
-  CUSTOM_MSG_PLAYER_SET_WEAPON_MODS,
-  CUSTOM_MSG_PLAYER_SET_STATS,
-  CUSTOM_MSG_PLAYER_SET_DOUBLE_POINTS,
-  CUSTOM_MSG_PLAYER_SET_DOUBLE_XP,
-  CUSTOM_MSG_PLAYER_SET_FREEZE,
-  CUSTOM_MSG_PLAYER_USE_ITEM,
-  CUSTOM_MSG_MOB_UNRELIABLE_MSG,
-  CUSTOM_MSG_WEAPON_PRESTIGE,
-  CUSTOM_MSG_INTERACT_BANK_BOX,
-  CUSTOM_MSG_WITHDRAWN_BANK_BOX,
-  CUSTOM_MSG_SET_ROUND_50_TIME,
-  CUSTOM_MSG_TELEPORT_BIG_AL,
-};
-
-enum BakedSpawnpointType
-{
-  BAKED_SPAWNPOINT_NONE = 0,
-  BAKED_SPAWNPOINT_UPGRADE = 1,
+	CUSTOM_MSG_ROUND_COMPLETE = CUSTOM_MSG_ID_GAME_MODE_START,
+	CUSTOM_MSG_ROUND_START,
+	CUSTOM_MSG_UPDATE_SPAWN_VARS,
+	CUSTOM_MSG_WEAPON_UPGRADE,
+	CUSTOM_MSG_REVIVE_PLAYER,
+	CUSTOM_MSG_PLAYER_DIED,
+	CUSTOM_MSG_PLAYER_SET_WEAPON_MODS,
+	CUSTOM_MSG_PLAYER_SET_STATS,
+	CUSTOM_MSG_PLAYER_SET_DOUBLE_POINTS,
+	CUSTOM_MSG_PLAYER_SET_DOUBLE_XP,
+	CUSTOM_MSG_PLAYER_SET_FREEZE,
+	CUSTOM_MSG_PLAYER_USE_ITEM,
+	CUSTOM_MSG_MOB_UNRELIABLE_MSG,
+	CUSTOM_MSG_WEAPON_PRESTIGE,
+	CUSTOM_MSG_INTERACT_BANK_BOX,
+	CUSTOM_MSG_WITHDRAWN_BANK_BOX,
+	CUSTOM_MSG_SET_ROUND_50_TIME,
+	CUSTOM_MSG_TELEPORT_BIG_AL,
 };
 
 enum MobStatId
 {
-  MOB_STAT_NONE               = 0,
-  MOB_STAT_ZOMBIE             = 1,
-  MOB_STAT_ZOMBIE_FREEZE      = 2,
-  MOB_STAT_ZOMBIE_ACID        = 3,
-  MOB_STAT_ZOMBIE_GHOST       = 4,
-  MOB_STAT_ZOMBIE_EXPLODE     = 5,
-  MOB_STAT_TREMOR             = 6,
-  MOB_STAT_EXECUTIONER        = 7,
-  MOB_STAT_SWARMER            = 8,
-  MOB_STAT_REACTOR            = 9,
-  MOB_STAT_REAPER             = 10,
-  MOB_STAT_LEVIATHAN          = 11,
-  MOB_STAT_COUNT
+	MOB_STAT_NONE = 0,
+	MOB_STAT_ZOMBIE = 1,
+	MOB_STAT_ZOMBIE_FREEZE = 2,
+	MOB_STAT_ZOMBIE_ACID = 3,
+	MOB_STAT_ZOMBIE_GHOST = 4,
+	MOB_STAT_ZOMBIE_EXPLODE = 5,
+	MOB_STAT_TREMOR = 6,
+	MOB_STAT_EXECUTIONER = 7,
+	MOB_STAT_SWARMER = 8,
+	MOB_STAT_REACTOR = 9,
+	MOB_STAT_REAPER = 10,
+	MOB_STAT_LEVIATHAN = 11,
+	MOB_STAT_COUNT
 };
 
 enum BlessingItemId
 {
-  BLESSING_ITEM_NONE           = 0,
-  BLESSING_ITEM_MULTI_JUMP     = 1,
-  BLESSING_ITEM_LUCK           = 2,
-  BLESSING_ITEM_BULL           = 3,
-  BLESSING_ITEM_ELEM_IMMUNITY  = 4,
-  BLESSING_ITEM_HEALTH_REGEN   = 5,
-  BLESSING_ITEM_AMMO_REGEN     = 6,
-  BLESSING_ITEM_THORNS         = 7,
-  BLESSING_ITEM_COUNT
+	BLESSING_ITEM_NONE = 0,
+	BLESSING_ITEM_MULTI_JUMP = 1,
+	BLESSING_ITEM_LUCK = 2,
+	BLESSING_ITEM_BULL = 3,
+	BLESSING_ITEM_ELEM_IMMUNITY = 4,
+	BLESSING_ITEM_HEALTH_REGEN = 5,
+	BLESSING_ITEM_AMMO_REGEN = 6,
+	BLESSING_ITEM_THORNS = 7,
+	BLESSING_ITEM_COUNT
 };
 
 enum StackableItemId
 {
-  STACKABLE_ITEM_LOW_HEALTH_DMG_BUF     = 0, // stack dmg buf
-  STACKABLE_ITEM_EXTRA_JUMP             = 1, // stack +1 jump
-  STACKABLE_ITEM_EXTRA_SHOT             = 2, // stack +1 shot (dmg mult)
-  STACKABLE_ITEM_HOVERBOOTS             = 3, // stack movement speed
-  STACKABLE_ITEM_ALPHA_MOD_SPEED        = 4, // stack +2 speed mod
-  STACKABLE_ITEM_ALPHA_MOD_IMPACT       = 5, // stack +2 impact mod
-  STACKABLE_ITEM_ALPHA_MOD_AREA         = 6, // stack +2 area mod
-  STACKABLE_ITEM_ALPHA_MOD_AMMO         = 7, // stack +2 ammo mod
-  STACKABLE_ITEM_VAMPIRE                = 8, // stack +X health gain
-  STACKABLE_ITEM_EXPLODING_ENEMIES      = 9, // stack +X damage per explosion
-  STACKABLE_ITEM_COUNT
+	STACKABLE_ITEM_LOW_HEALTH_DMG_BUF = 0, // stack dmg buf
+	STACKABLE_ITEM_EXTRA_JUMP = 1,				 // stack +1 jump
+	STACKABLE_ITEM_EXTRA_SHOT = 2,				 // stack +1 shot (dmg mult)
+	STACKABLE_ITEM_HOVERBOOTS = 3,				 // stack movement speed
+	STACKABLE_ITEM_ALPHA_MOD_SPEED = 4,		 // stack +2 speed mod
+	STACKABLE_ITEM_ALPHA_MOD_IMPACT = 5,	 // stack +2 impact mod
+	STACKABLE_ITEM_ALPHA_MOD_AREA = 6,		 // stack +2 area mod
+	STACKABLE_ITEM_ALPHA_MOD_AMMO = 7,		 // stack +2 ammo mod
+	STACKABLE_ITEM_VAMPIRE = 8,						 // stack +X health gain
+	STACKABLE_ITEM_EXPLODING_ENEMIES = 9,	 // stack +X damage per explosion
+	STACKABLE_ITEM_COUNT
 };
 
 struct MobConfig;
 struct MobSpawnEventArgs;
 struct MobSpawnParams;
 
-typedef void (*UpgradePlayerWeapon_func)(int playerId, int weaponId, int giveAlphaMod);
-typedef void (*PushSnack_func)(char * string, int ticksAlive, int localPlayerIdx);
-typedef void (*PopulateSpawnArgs_func)(struct MobSpawnEventArgs* output, struct MobConfig* config, int spawnParamsIdx, int isBaseConfig, int spawnFlags);
-typedef int (*ModeCreateMob_func)(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, int spawnFlags, struct MobConfig *config);
-typedef int (*SpawnGetRandomPoint_func)(VECTOR out, struct MobSpawnParams* mob);
-typedef void (*ModeMobNuke_func)(int killedByPlayerId);
-typedef void (*ModeSetDoublePoints_func)(int isActive);
-typedef void (*ModeSetDoubleXP_func)(int isActive);
-typedef void (*ModeSetFreezeMobs_func)(int isActive);
-typedef void (*ModeRevivePlayer_func)(Player* player, int fromPlayerId);
-
-typedef void (*MapOnMobSpawned_func)(Moby* moby);
-typedef int (*MapOnMobCreate_func)(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, int spawnFlags, struct MobConfig *config);
-typedef void (*MapOnMobKilled_func)(Moby* moby, int killedByPlayerId, int killedByWeaponId);
-typedef int (*MapCanSpawnMobs_func)(void);
-typedef int (*MapGetSpawnPoints_func)(int** outSpawnPointIndices);
-typedef int (*MapConsiderMobSpawnPoint_func)(struct MobSpawnParams* mobSpawnParams, VECTOR position, float yaw, Player* targetPlayer);
-typedef int (*OnPlayerGetRes_func)(Player* player, VECTOR outPos, VECTOR outRot, int firstRes);
-typedef int (*CreateUpgradePickup_func)(VECTOR position, VECTOR rotation, enum UpgradeType upgradeType);
-typedef int (*HandleUpgradePickupEvent_func)(Moby* moby, GuberEvent* event);
-typedef void (*PickupUpgradePickup_func)(Moby* moby, int pickedUpByPlayerId);
-typedef int (*CreateMobDrop_func)(VECTOR position, enum DropType dropType, int destroyAtTime, int team);
-typedef int (*HandleMobDropEvent_func)(Moby* moby, GuberEvent* event);
-typedef int (*FrameTick_func)(void);
-
-typedef struct GuberMoby* (*GetGuber_func)(Moby* moby);
-typedef int (*HandleGuberEvent_func)(Moby* moby, GuberEvent* event);
-
-typedef struct SurvivalBakedSpawnpoint
-{
-  enum BakedSpawnpointType Type;
-  int Params;
-  float Position[3];
-  float Rotation[3];
-} SurvivalBakedSpawnpoint_t;
-
-typedef struct SurvivalBakedConfig
-{
-  float Difficulty;
-  float BoltMultiplier;
-  float XpMultiplier;
-  float SpawnDistanceFactor;
-  int BoltRankMultiplier;
-  SurvivalBakedSpawnpoint_t BakedSpawnPoints[BAKED_SPAWNPOINT_COUNT];
-  int StackboxBaseCost;
-  int StackboxCostPerPerk;
-  char WeaponPrestigeMax;
-  int PrestigeCostPerLevel[WEAPON_PRESTIGE_MAX];
-} SurvivalBakedConfig_t;
-
 struct SurvivalPlayerState
 {
-  u64 TotalBolts;
-  u32 XP;
-  int Bolts;
-  int Kills;
-  int Revives;
-  int TimesRevived;
-  int TimesRevivedSinceRoundStart;
-  int TotalTokens;
-  int CurrentTokens;
-  int Item;
-  int BestRound;
-  int TimesRolledMysteryBox;
-  int TimesActivatedDemonBell;
-  int TimesActivatedPower;
-  int TokensUsedOnGates;
-  int BlessingSlots;
-  short Upgrades[UPGRADE_COUNT];
-  short AlphaMods[8];
-  char ItemBlessings[PLAYER_MAX_BLESSINGS];
-  char WeaponPrestige[9];
-  char BestWeaponLevel[9];
-  u8 ItemStackable[STACKABLE_ITEM_COUNT];
+	u64 TotalBolts;
+	u32 XP;
+	int Bolts;
+	int Kills;
+	int Revives;
+	int TimesRevived;
+	int TimesRevivedSinceRoundStart;
+	int TotalTokens;
+	int CurrentTokens;
+	int Item;
+	int BestRound;
+	int TimesRolledMysteryBox;
+	int TimesActivatedDemonBell;
+	int TimesActivatedPower;
+	int TokensUsedOnGates;
+	int BlessingSlots;
+	short Upgrades[UPGRADE_COUNT];
+	short AlphaMods[8];
+	char ItemBlessings[PLAYER_MAX_BLESSINGS];
+	char WeaponPrestige[9];
+	char BestWeaponLevel[9];
+	u8 ItemStackable[STACKABLE_ITEM_COUNT];
 };
 
 struct SurvivalPlayer
 {
-  float MinSqrDistFromMob;
-  float MaxSqrDistFromMob;
-  float LastHealth;
-  struct SurvivalPlayerState State;
-  int TimeOfDoublePoints;
-  int TimeOfDoubleXP;
-  int InvisibilityCloakStopTime;
-  int HealthTornadoStopTime;
-  int HealthTornadoActivateTicks;
-  int TicksSinceHealthChanged;
-  int RevivingPlayerId;
-  u16 ReviveCooldownTicks;
-  u16 RevivingPlayerTicks;
-  u8 ActionCooldownTicks;
-  u8 MessageCooldownTicks;
-  char IsLocal;
-  char IsDead;
-  char IsInWeaponsMenu;
-  char IsDoublePoints;
-  char IsDoubleXP;
-  char HealthBarStrBuf[8];
+	float MinSqrDistFromMob;
+	float MaxSqrDistFromMob;
+	float LastHealth;
+	struct SurvivalPlayerState State;
+	int TimeOfDoublePoints;
+	int TimeOfDoubleXP;
+	int InvisibilityCloakStopTime;
+	int HealthTornadoStopTime;
+	int HealthTornadoActivateTicks;
+	int TicksSinceHealthChanged;
+	int RevivingPlayerId;
+	u16 ReviveCooldownTicks;
+	u16 RevivingPlayerTicks;
+	u8 ActionCooldownTicks;
+	u8 MessageCooldownTicks;
+	char IsLocal;
+	char IsDead;
+	char IsInWeaponsMenu;
+	char IsDoublePoints;
+	char IsDoubleXP;
+	char HealthBarStrBuf[8];
 };
 
 struct SurvivalMobStats
 {
-  int MobsDrawnCurrent;
-  int MobsDrawnLast;
-  int MobsDrawGameTime;
-  int TotalSpawning;
-  int TotalAlive;
-  int TotalSpawnedThisRound;
-  int TotalSpawned;
-  int NumSpawnedThisRound[MAX_MOB_SPAWN_PARAMS];
-  u8 NumAlive[MAX_MOB_SPAWN_PARAMS];
+	int MobsDrawnCurrent;
+	int MobsDrawnLast;
+	int MobsDrawGameTime;
+	int TotalSpawning;
+	int TotalAlive;
+	int TotalSpawnedThisRound;
+	int TotalSpawned;
+	int NumSpawnedThisRound[MAX_MOB_SPAWN_PARAMS];
+	u8 NumAlive[MAX_MOB_SPAWN_PARAMS];
 };
 
 struct SurvivalState
 {
-  int RoundNumber;
-  int RoundStartTime;
-  int RoundCompleteTime;
-  int RoundEndTime;
-  int RoundMaxMobCount;
-  int RoundMaxSpawnedAtOnce;
-  int RoundSpawnTicker;
-  int RoundSpawnTickerCounter;
-  int RoundNextSpawnTickerCounter;
-  int RoundDemonBellCount;
-  int RoundIsSpecial;
-  int RoundSpecialIdx;
-  int InitializedTime;
-  int DemonBellCount;
-  int MapBaseComplexity;
-  struct SurvivalMobStats MobStats;
-  struct SurvivalPlayer PlayerStates[GAME_MAX_PLAYERS];
-  char ClientReady[GAME_MAX_PLAYERS];
-  int RoundInitialized;
-  Moby* Vendor;
-  Moby* BigAl;
-  Moby* PrestigeMachine;
-  Moby* Bankbox;
-  Moby* UpgradeMobies[UPGRADE_COUNT];
-  Moby* MysteryBoxMoby;
-  struct SurvivalPlayer* LocalPlayerState;
-  int GameOver;
-  int WinningTeam;
-  int ActivePlayerCount;
-  int IsHost;
-  float Difficulty;
-  int TimeOfFreeze;
-  int InfiniteAmmoStopTime;
-  short DropCooldownTicks;
-  char Freeze;
-  char NumTeams;
-  int Round50Time;
-  Moby* BossMoby;
-  Moby** AllMobsSorted;
+	int RoundNumber;
+	int RoundStartTime;
+	int RoundCompleteTime;
+	int RoundEndTime;
+	int RoundMaxMobCount;
+	int RoundMaxSpawnedAtOnce;
+	int RoundSpawnTicker;
+	int RoundSpawnTickerCounter;
+	int RoundNextSpawnTickerCounter;
+	int RoundDemonBellCount;
+	int RoundIsSpecial;
+	int RoundSpecialIdx;
+	int InitializedTime;
+	int DemonBellCount;
+	int MapBaseComplexity;
+	struct SurvivalMobStats MobStats;
+	struct SurvivalPlayer PlayerStates[GAME_MAX_PLAYERS];
+	char ClientReady[GAME_MAX_PLAYERS];
+	int RoundInitialized;
+	Moby *Vendor;
+	Moby *BigAl;
+	Moby *PrestigeMachine;
+	Moby *Bankbox;
+	Moby *UpgradeMobies[UPGRADE_COUNT];
+	Moby *MysteryBoxMoby;
+	struct SurvivalPlayer *LocalPlayerState;
+	int GameOver;
+	int WinningTeam;
+	int ActivePlayerCount;
+	int IsHost;
+	float Difficulty;
+	int TimeOfFreeze;
+	int InfiniteAmmoStopTime;
+	short DropCooldownTicks;
+	char Freeze;
+	char NumTeams;
+	int Round50Time;
+	Moby *BossMoby;
+	Moby **AllMobsSorted;
 };
 
-struct UpgradeDef {
-  enum UpgradeType Id;
-  short Max;
-};
-
-struct SurvivalMapConfig
+struct UpgradeDef
 {
-  u32 Magic;
-  int ClientsReady;
-  struct SurvivalState* State;
-  struct SurvivalBakedConfig* BakedConfig;
-
-  struct MobSpawnParams* DefaultSpawnParams;
-  int DefaultSpawnParamsCount;
-  
-  struct SurvivalSpecialRoundParam* SpecialRoundParams;
-  int SpecialRoundParamsCount; 
-  
-  struct UpgradeDef* UpgradeDefs;
-  int UpgradeDefCount;
-  
-  // mode
-  SpawnGetRandomPoint_func SpawnGetRandomPointFunc;
-  UpgradePlayerWeapon_func UpgradePlayerWeaponFunc;
-  PushSnack_func PushSnackFunc;
-  PopulateSpawnArgs_func PopulateSpawnArgsFunc;
-  ModeCreateMob_func ModeCreateMobFunc;
-  ModeMobNuke_func ModeMobNukeFunc;
-  ModeSetDoublePoints_func ModeSetDoublePointsFunc;
-  ModeSetDoubleXP_func ModeSetDoubleXPFunc;
-  ModeSetFreezeMobs_func ModeSetFreezeMobsFunc;
-  ModeRevivePlayer_func ModeRevivePlayerFunc;
-  GetGuber_func OnGetGuberFunc;
-  HandleGuberEvent_func OnGuberEventFunc;
-
-  // map
-  MapOnMobCreate_func OnMobCreateFunc;
-  MapOnMobSpawned_func OnMobSpawnedFunc;
-  MapOnMobKilled_func OnMobKilledFunc;
-  MapCanSpawnMobs_func CanSpawnMobsFunc;
-  MapGetSpawnPoints_func GetSpawnPointsFunc;
-  MapConsiderMobSpawnPoint_func ConsiderMobSpawnPointFunc;
-  OnPlayerGetRes_func OnPlayerGetResFunc;
-  CreateUpgradePickup_func CreateUpgradePickupFunc;
-  HandleUpgradePickupEvent_func OnUpgradePickupEventFunc;
-  PickupUpgradePickup_func PickupUpgradeFunc;
-  CreateMobDrop_func CreateMobDropFunc;
-  HandleMobDropEvent_func OnMobDropEventFunc;
-  FrameTick_func OnFrameTickFunc;
-
-  // misc
-  float WeaponPickupCooldownFactor;
+	enum UpgradeType Id;
+	short Max;
 };
 
 struct SurvivalSpecialRoundParam
 {
-  int MinRound;
-  int RepeatEveryNRounds;
-  int RepeatCount;
-  int SpawnParamCount;
-  float SpawnCountFactor;
-  float SpawnRateFactor;
-  int MaxSpawnedAtOnce;
-  char UnlimitedPostRoundTime;
-  char DisableDrops;
-  char SpawnParamIds[4];
-  char Name[32];
+	int MinRound;
+	int RepeatEveryNRounds;
+	int RepeatCount;
+	int SpawnParamCount;
+	float SpawnCountFactor;
+	float SpawnRateFactor;
+	int MaxSpawnedAtOnce;
+	char UnlimitedPostRoundTime;
+	char DisableDrops;
+	char SpawnParamIds[4];
+	char Name[32];
+};
+
+struct SurvivalMapConfig
+{
+	u32 Magic;
+	int ClientsReady;
+	struct SurvivalState *State;
+
+	struct MobSpawnParams *DefaultSpawnParams;
+	int DefaultSpawnParamsCount;
+
+	struct SurvivalSpecialRoundParam *SpecialRoundParams;
+	int SpecialRoundParamsCount;
+
+	struct UpgradeDef *UpgradeDefs;
+	int UpgradeDefCount;
+
+	struct SurvivalInteropTable Functions;
 };
 
 typedef void (*GambitCustomInit_func)(void);
 typedef void (*GambitCustomTick_func)(void);
 typedef void (*GambitCustomOnRoundComplete_func)(int roundNumber);
-typedef struct GambitDef {
-  GambitCustomInit_func CustomInit;
-  GambitCustomTick_func CustomTick;
-  GambitCustomOnRoundComplete_func CustomOnRoundComplete;
-  int CompleteAfterRound; // use 0 for manual completion
-  float DifficultyMultiplier;
-  float XpMultiplier;
-  float BoltMultiplier;
-  float MobDamageScaleMultiplier;
-  float MobSpeedScaleMultiplier;
-  float MobHealthScaleMultiplier;
-  int InitialBolts;
-  int InitialTokens;
-  char ForceWeaponId;     // use 0 for none
-  char DisableRevives;
-  char DisableVendor;
-  char DisableBank;
-  char DisablePrestigeMachine;
-  char DisableStackables;
-  char InstantRespawnMysteryBox;
+typedef struct GambitDef
+{
+	GambitCustomInit_func CustomInit;
+	GambitCustomTick_func CustomTick;
+	GambitCustomOnRoundComplete_func CustomOnRoundComplete;
+	int CompleteAfterRound; // use 0 for manual completion
+	float DifficultyMultiplier;
+	float XpMultiplier;
+	float BoltMultiplier;
+	float MobDamageScaleMultiplier;
+	float MobSpeedScaleMultiplier;
+	float MobHealthScaleMultiplier;
+	int InitialBolts;
+	int InitialTokens;
+	char ForceWeaponId; // use 0 for none
+	char DisableRevives;
+	char DisableVendor;
+	char DisableBank;
+	char DisablePrestigeMachine;
+	char DisableStackables;
+	char InstantRespawnMysteryBox;
 } GambitDef_t;
 
 struct SurvivalGameData
 {
-  u32 Version;
-  u32 RoundNumber;
-  u32 Round50Time;
-  u64 Points[GAME_MAX_PLAYERS];
-  int Kills[GAME_MAX_PLAYERS];
-  int Revives[GAME_MAX_PLAYERS];
-  int TimesRevived[GAME_MAX_PLAYERS];
-  short BestRound[GAME_MAX_PLAYERS];
+	u32 Version;
+	u32 RoundNumber;
+	u32 Round50Time;
+	u64 Points[GAME_MAX_PLAYERS];
+	int Kills[GAME_MAX_PLAYERS];
+	int Revives[GAME_MAX_PLAYERS];
+	int TimesRevived[GAME_MAX_PLAYERS];
+	short BestRound[GAME_MAX_PLAYERS];
 };
-
-typedef struct SurvivalRoundCompleteMessage
-{
-  int GameTime;
-  int BoltBonus;
-} SurvivalRoundCompleteMessage_t;
-
-typedef struct SurvivalPlayerWithdrawnBankBoxMessage
-{
-  int Amount;
-  char PlayerId;
-} SurvivalPlayerWithdrawnBankBoxMessage_t;
-
-typedef struct SurvivalPlayerInteractBankBoxMessage
-{
-  int Amount;
-  char PlayerId;
-  char Deposit;
-} SurvivalPlayerInteractBankBoxMessage_t;
-
-typedef struct SurvivalPlayerInteractStackBoxMessage
-{
-  char PlayerId;
-  char ItemId;
-} SurvivalPlayerInteractStackBoxMessage_t;
-
-typedef struct SurvivalWeaponUpgradeMessage
-{
-  char PlayerId;
-  char WeaponId;
-  char Level;
-  char Alphamod;
-} SurvivalWeaponUpgradeMessage_t;
-
-typedef struct SurvivalWeaponPrestigeMessage
-{
-  char PlayerId;
-  char WeaponId;
-  char PrestigeId;
-} SurvivalWeaponPrestigeMessage_t;
-
-typedef struct SurvivalRoundStartMessage
-{
-  int GameTime;
-  int RoundNumber;
-} SurvivalRoundStartMessage_t;
-
-typedef struct SurvivalReviveMessage
-{
-  int PlayerId;
-  int FromPlayerId;
-} SurvivalReviveMessage_t;
-
-typedef struct SurvivalSetPlayerDeadMessage
-{
-  int PlayerId;
-  char IsDead;
-} SurvivalSetPlayerDeadMessage_t;
-
-typedef struct SurvivalSetWeaponModsMessage
-{
-  int PlayerId;
-  u8 WeaponId;
-  u8 Mods[10];
-} SurvivalSetWeaponModsMessage_t;
-
-typedef struct SurvivalSetPlayerStatsMessage
-{
-  int PlayerId;
-  struct SurvivalPlayerState Stats;
-} SurvivalSetPlayerStatsMessage_t;
-
-typedef struct SurvivalSetPlayerDoublePointsMessage
-{
-  int TimeOfDoublePoints[GAME_MAX_PLAYERS];
-  char IsActive[GAME_MAX_PLAYERS];
-} SurvivalSetPlayerDoublePointsMessage_t;
-
-typedef struct SurvivalSetPlayerDoubleXPMessage
-{
-  int TimeOfDoubleXP[GAME_MAX_PLAYERS];
-  char IsActive[GAME_MAX_PLAYERS];
-} SurvivalSetPlayerDoubleXPMessage_t;
-
-typedef struct SurvivalSetFreezeMessage
-{
-  char IsActive;
-} SurvivalSetFreezeMessage_t;
-
-typedef struct SurvivalPlayerUseItem
-{
-  int PlayerId;
-  enum MysteryBoxItem Item;
-} SurvivalPlayerUseItem_t;
-
-struct SurvivalSnackItem
-{
-  int TicksAlive;
-  char DisplayForLocalPlayerIdx;
-  char Str[64];
-};
-
-extern const int UPGRADE_COST[];
-extern const float BOLT_TAX[];
-extern const char WEAPON_PICKUP_BASE_RESPAWN_TIMES[];
-extern const char WEAPON_PICKUP_PLAYER_RESPAWN_TIME_OFFSETS[];
-extern const char ENABLED_ALPHA_MODS[];
-extern const int ENABLED_ALPHA_MODS_COUNT;
-
-struct GuberMoby* getGuber(Moby* moby);
-int handleEvent(Moby* moby, GuberEvent* event);
 
 #endif // SURVIVAL_GAME_H

--- a/codegen/rc4/survival/interop.c
+++ b/codegen/rc4/survival/interop.c
@@ -1,0 +1,189 @@
+#include <libdl/area.h>
+#include <libdl/spawnpoint.h>
+#include <libdl/stdio.h>
+#include "mob.h"
+#include "config.h"
+#include "interop.h"
+#include "utils.h"
+#include "maputils.h"
+
+const char *SURVIVAL_PRESTIGE_WEAPON_NEED_V10_MESSAGE = "Your weapon is not powerful enough";
+const char *SURVIVAL_PRESTIGE_WEAPON_MAXED_MESSAGE = "Your weapon is too powerful";
+
+//--------------------------------------------------------------------------
+void mapOnMobKilled(Moby *moby, int killedByPlayerId, int killedByWeaponId)
+{
+#if STACKABLES
+	stackableOnMobKilled(moby, killedByPlayerId, killedByWeaponId);
+#endif
+
+#if SOULCOLLECTOR
+	soulcollectorOnSoul(moby->Position, killedByPlayerId);
+#endif
+
+#ifdef AMMO_DROP_PROBABILITY
+	Player *player = playerGetAll()[killedByPlayerId];
+	if (playerIsValid(player) && player->IsLocal && randRange(0, 1) < AMMO_DROP_PROBABILITY)
+	{
+		ammodropCreateAt(moby);
+	}
+#endif
+}
+
+//--------------------------------------------------------------------------
+int mapCanSpawnMobs(void)
+{
+#if DEBUG_MANUAL_SPAWNING
+	return 0;
+#endif
+
+	return 1;
+}
+
+//--------------------------------------------------------------------------
+int mapGetSpawnPoints(int **outSpawnPointIndices)
+{
+	Area_t area;
+	if (mobSpawnPointsAreaIdx < 0 || !areaGetArea(mobSpawnPointsAreaIdx, &area))
+	{
+		*outSpawnPointIndices = NULL;
+		return 0;
+	}
+
+	*outSpawnPointIndices = area.Cuboids;
+	return area.CuboidCount;
+}
+
+//--------------------------------------------------------------------------
+int mapConsiderMobSpawnPoint(struct MobSpawnParams *mobSpawnParams, VECTOR position, float yaw, Player *targetPlayer)
+{
+	if (!targetPlayer || !targetPlayer->PlayerMoby)
+		return 1;
+
+	// check if we have a path to
+	// if not, don't spawn here
+	if (!pathHasRouteFromTo(pathGetClosestNodeIdx(position), pathTargetCacheGetClosestNodeIdx(targetPlayer->PlayerMoby)))
+	{
+		return 0;
+	}
+
+	return 1;
+}
+
+//--------------------------------------------------------------------------
+float mapGetDifficultyMultiplier(void)
+{
+	return bakedConfig.Difficulty;
+}
+
+//--------------------------------------------------------------------------
+float mapGetBoltMultiplier(void)
+{
+	return bakedConfig.BoltMultiplier;
+}
+
+//--------------------------------------------------------------------------
+float mapGetXpMultiplier(void)
+{
+	return bakedConfig.XpMultiplier;
+}
+
+//--------------------------------------------------------------------------
+int mapGetBoltRankMultiplier(void)
+{
+	return bakedConfig.BoltRankMultiplier;
+}
+
+//--------------------------------------------------------------------------
+float mapGetSpawnDistanceMultiplier(void)
+{
+	return bakedConfig.SpawnDistanceMultiplier;
+}
+
+//--------------------------------------------------------------------------
+float mapGetWeaponPickupCooldownMultiplier(void)
+{
+	return bakedConfig.WeaponPickupCooldownMultiplier;
+}
+
+//--------------------------------------------------------------------------
+struct SurvivalBakedSpawnpoint *mapGetBakedSpawnPoints(int *count)
+{
+	if (count)
+		*count = BAKED_SPAWNPOINT_COUNT;
+	return bakedConfig.BakedSpawnPoints;
+}
+
+//--------------------------------------------------------------------------
+int mapCanPrestigePlayerWeapon(Player *player, int gadgetId, int prestigeNum, char **outMsg)
+{
+	// cap prestige at max
+	if (prestigeNum > bakedConfig.WeaponPrestigeMax)
+	{
+		if (outMsg)
+			*outMsg = SURVIVAL_PRESTIGE_WEAPON_MAXED_MESSAGE;
+
+		return 0;
+	}
+
+	// must be v10
+	if (player->GadgetBox->Gadgets[gadgetId].Level != VENDOR_MAX_WEAPON_LEVEL)
+	{
+		if (outMsg)
+			*outMsg = SURVIVAL_PRESTIGE_WEAPON_NEED_V10_MESSAGE;
+
+		return 0;
+	}
+
+	return 1;
+}
+
+//--------------------------------------------------------------------------
+u32 mapGetPrestigePlayerWeaponCost(Player *player, int gadgetId, int levelNum)
+{
+	return bakedConfig.PrestigeCostPerLevel[levelNum];
+}
+
+//--------------------------------------------------------------------------
+int mapCanUpgradePlayerWeapon(Player *player, int gadgetId, int levelNum)
+{
+	// only can upgrade weapon gadgets
+	switch (gadgetId)
+	{
+	case WEAPON_ID_VIPERS:
+	case WEAPON_ID_MAGMA_CANNON:
+	case WEAPON_ID_ARBITER:
+	case WEAPON_ID_FUSION_RIFLE:
+	case WEAPON_ID_MINE_LAUNCHER:
+	case WEAPON_ID_B6:
+	case WEAPON_ID_OMNI_SHIELD:
+	case WEAPON_ID_FLAIL:
+		break;
+	default:
+		return 0;
+	}
+
+	// max v10
+	return levelNum < VENDOR_MAX_WEAPON_LEVEL;
+}
+
+//--------------------------------------------------------------------------
+u32 mapGetUpgradePlayerWeaponCost(Player *player, int gadgetId, int levelNum)
+{
+	if (!player)
+		return 0;
+
+	if (levelNum < 0 || levelNum >= VENDOR_MAX_WEAPON_LEVEL)
+		return 0;
+
+	return bakedConfig.VendorCost[levelNum];
+}
+
+//--------------------------------------------------------------------------
+u32 mapGetXpForNextToken(Player *player, int token)
+{
+	if (token > SURVIVAL_XP_CURVE_FLATTEN_AFTER_N_TOKENS)
+		return (u32)(250 * powf(1.05, SURVIVAL_XP_CURVE_FLATTEN_AFTER_N_TOKENS));
+
+	return (u32)(250 * powf(1.05, token));
+}

--- a/codegen/rc4/survival/interop.h
+++ b/codegen/rc4/survival/interop.h
@@ -1,0 +1,119 @@
+#ifndef SURVIVAL_INTEROP_H
+#define SURVIVAL_INTEROP_H
+
+// override in Forge with CustomCodeGen define SURVIVAL_XP_CURVE_FLATTEN_AFTER_N_TOKENS=N
+#ifndef SURVIVAL_XP_CURVE_FLATTEN_AFTER_N_TOKENS
+#define SURVIVAL_XP_CURVE_FLATTEN_AFTER_N_TOKENS (50)
+#endif
+
+#include <libdl/moby.h>
+#include <libdl/player.h>
+#include "config.h"
+#include "drop.h"
+#include "upgrade.h"
+
+struct MobConfig;
+struct MobSpawnEventArgs;
+struct MobSpawnParams;
+struct SurvivalBakedSpawnpoint;
+
+typedef void (*ModeUpgradePlayerWeapon_func)(int playerId, int weaponId, int giveAlphaMod);
+typedef void (*ModePushSnack_func)(char *string, int ticksAlive, int localPlayerIdx);
+typedef void (*ModePushBubble_func)(VECTOR position, float randomRadius, float damage, int isLocal, int team);
+typedef void (*ModePopulateSpawnArgs_func)(struct MobSpawnEventArgs *output, struct MobConfig *config, int spawnParamsIdx, int isBaseConfig, int spawnFlags);
+typedef int (*ModeCreateMob_func)(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, int spawnFlags, struct MobConfig *config);
+typedef int (*ModeSpawnGetRandomPoint_func)(VECTOR out, struct MobSpawnParams *mob);
+typedef void (*ModeMobNuke_func)(int killedByPlayerId);
+typedef void (*ModeSetDoublePoints_func)(int isActive);
+typedef void (*ModeSetDoubleXP_func)(int isActive);
+typedef void (*ModeSetFreezeMobs_func)(int isActive);
+typedef void (*ModeRevivePlayer_func)(Player *player, int fromPlayerId);
+
+typedef struct GuberMoby *(*ModeGetGuber_func)(Moby *moby);
+typedef int (*ModeHandleGuberEvent_func)(Moby *moby, GuberEvent *event);
+
+typedef void (*MapOnMobSpawned_func)(Moby *moby);
+typedef int (*MapOnMobCreate_func)(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, int spawnFlags, struct MobConfig *config);
+typedef void (*MapOnMobKilled_func)(Moby *moby, int killedByPlayerId, int killedByWeaponId);
+typedef int (*MapCanSpawnMobs_func)(void);
+typedef int (*MapGetSpawnPoints_func)(int **outSpawnPointIndices);
+typedef int (*MapConsiderMobSpawnPoint_func)(struct MobSpawnParams *mobSpawnParams, VECTOR position, float yaw, Player *targetPlayer);
+typedef int (*MapOnPlayerGetRes_func)(Player *player, VECTOR outPos, VECTOR outRot, int firstRes);
+typedef int (*MapCreateUpgradePickup_func)(VECTOR position, VECTOR rotation, enum UpgradeType upgradeType);
+typedef void (*MapPickupUpgradePickup_func)(Moby *moby, int pickedUpByPlayerId);
+typedef int (*MapCreateMobDrop_func)(VECTOR position, enum DropType dropType, int destroyAtTime, int team);
+typedef void (*MapFrameTick_func)(void);
+typedef float (*MapGetDifficultyMultiplier_func)(void);
+typedef float (*MapGetBoltMultiplier_func)(void);
+typedef float (*MapGetXpMultiplier_func)(void);
+typedef int (*MapGetBoltRankMultiplier_func)(void);
+typedef float (*MapGetSpawnDistanceMultiplier_func)(void);
+typedef float (*MapGetWeaponPickupCooldownMultiplier_func)(void);
+typedef struct SurvivalBakedSpawnpoint *(*MapGetBakedSpawnPoints_func)(int *count);
+typedef int (*MapCanPrestigePlayerWeapon_func)(Player *player, int gadgetId, int prestigeNum, char **outMsg);
+typedef u32 (*MapGetPrestigePlayerWeaponCost_func)(Player *player, int gadgetId, int prestigeNum);
+typedef int (*MapCanUpgradePlayerWeapon_func)(Player *player, int gadgetId, int levelNum);
+typedef u32 (*MapGetUpgradePlayerWeaponCost_func)(Player *player, int gadgetId, int levelNum);
+typedef u32 (*MapGetXpForNextToken_func)(Player *player, int token);
+
+struct SurvivalInteropTable
+{
+	// mode
+	ModeSpawnGetRandomPoint_func ModeSpawnGetRandomPointFunc;
+	ModeUpgradePlayerWeapon_func ModeUpgradePlayerWeaponFunc;
+	ModePushSnack_func ModePushSnackFunc;
+	ModePushBubble_func ModePushBubbleFunc;
+	ModePopulateSpawnArgs_func ModePopulateSpawnArgsFunc;
+	ModeCreateMob_func ModeCreateMobFunc;
+	ModeMobNuke_func ModeMobNukeFunc;
+	ModeSetDoublePoints_func ModeSetDoublePointsFunc;
+	ModeSetDoubleXP_func ModeSetDoubleXPFunc;
+	ModeSetFreezeMobs_func ModeSetFreezeMobsFunc;
+	ModeRevivePlayer_func ModeRevivePlayerFunc;
+	ModeGetGuber_func ModeOnGetGuberFunc;
+	ModeHandleGuberEvent_func ModeOnGuberEventFunc;
+
+	// map
+	MapOnMobCreate_func OnMobCreateFunc;
+	MapOnMobSpawned_func OnMobSpawnedFunc;
+	MapOnMobKilled_func OnMobKilledFunc;
+	MapCanSpawnMobs_func CanSpawnMobsFunc;
+	MapGetSpawnPoints_func GetSpawnPointsFunc;
+	MapConsiderMobSpawnPoint_func ConsiderMobSpawnPointFunc;
+	MapOnPlayerGetRes_func OnPlayerGetResFunc;
+	MapCreateUpgradePickup_func CreateUpgradePickupFunc;
+	MapPickupUpgradePickup_func PickupUpgradeFunc;
+	MapCreateMobDrop_func CreateMobDropFunc;
+	MapFrameTick_func OnFrameTickFunc;
+	MapGetDifficultyMultiplier_func GetDifficultyMultiplierFunc;
+	MapGetBoltMultiplier_func GetBoltMultiplierFunc;
+	MapGetXpMultiplier_func GetXpMultiplierFunc;
+	MapGetBoltRankMultiplier_func GetBoltRankMultiplierFunc;
+	MapGetSpawnDistanceMultiplier_func GetSpawnDistanceMultiplierFunc;
+	MapGetWeaponPickupCooldownMultiplier_func GetWeaponPickupCooldownMultiplierFunc;
+	MapGetBakedSpawnPoints_func GetBakedSpawnPointsFunc;
+	MapCanPrestigePlayerWeapon_func CanPrestigePlayerWeaponFunc;
+	MapGetPrestigePlayerWeaponCost_func GetPrestigePlayerWeaponCostFunc;
+	MapCanUpgradePlayerWeapon_func CanUpgradePlayerWeaponFunc;
+	MapGetUpgradePlayerWeaponCost_func GetUpgradePlayerWeaponCostFunc;
+	MapGetXpForNextToken_func GetXpForNextTokenFunc;
+};
+
+void mapOnMobKilled(Moby *moby, int killedByPlayerId, int killedByWeaponId);
+int mapCanSpawnMobs(void);
+int mapGetSpawnPoints(int **outSpawnPointIndices);
+int mapConsiderMobSpawnPoint(struct MobSpawnParams *mobSpawnParams, VECTOR position, float yaw, Player *targetPlayer);
+float mapGetDifficultyMultiplier(void);
+float mapGetBoltMultiplier(void);
+float mapGetXpMultiplier(void);
+int mapGetBoltRankMultiplier(void);
+float mapGetSpawnDistanceMultiplier(void);
+float mapGetWeaponPickupCooldownMultiplier(void);
+struct SurvivalBakedSpawnpoint *mapGetBakedSpawnPoints(int *count);
+int mapCanPrestigePlayerWeapon(Player *player, int gadgetId, int prestigeNum, char **outMsg);
+u32 mapGetPrestigePlayerWeaponCost(Player *player, int gadgetId, int prestigeNum);
+int mapCanUpgradePlayerWeapon(Player *player, int gadgetId, int levelNum);
+u32 mapGetUpgradePlayerWeaponCost(Player *player, int gadgetId, int levelNum);
+u32 mapGetXpForNextToken(Player *player, int token);
+
+#endif // SURVIVAL_INTEROP_H

--- a/codegen/rc4/survival/mobs/mob.c
+++ b/codegen/rc4/survival/mobs/mob.c
@@ -1439,8 +1439,8 @@ int mobCreate(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, 
 	guberMobyCreateSpawned(spawnParams->OClass, sizeof(struct MobPVar) + extraDataSize, &guberEvent, NULL);
 	if (guberEvent)
 	{
-    if (MapConfig.PopulateSpawnArgsFunc) {
-      MapConfig.PopulateSpawnArgsFunc(&args, config, spawnParamsIdx, spawnFromUID == -1, spawnFlags);
+    if (MapConfig.Functions.ModePopulateSpawnArgsFunc) {
+      MapConfig.Functions.ModePopulateSpawnArgsFunc(&args, config, spawnParamsIdx, spawnFromUID == -1, spawnFlags);
     }
 
 		u8 random = (u8)rand(100);
@@ -1477,7 +1477,7 @@ int mobCreate(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, 
 //--------------------------------------------------------------------------
 void mobInit(void)
 {
-  MapConfig.OnMobSpawnedFunc = &mobOnSpawned;
+  MapConfig.Functions.OnMobSpawnedFunc = &mobOnSpawned;
 }
 
 //--------------------------------------------------------------------------

--- a/codegen/rc4/survival/mobs/reactor.c
+++ b/codegen/rc4/survival/mobs/reactor.c
@@ -449,9 +449,9 @@ int reactorOnRespawn(Moby* moby)
 
   // don't let mode destroy and respawn
   // manually teleport reactor to random spawn point
-  if (MapConfig.SpawnGetRandomPointFunc) {
+  if (MapConfig.Functions.ModeSpawnGetRandomPointFunc) {
     VECTOR p;
-    MapConfig.SpawnGetRandomPointFunc(p, &MapConfig.DefaultSpawnParams[pvars->MobVars.SpawnParamsIdx]);
+    MapConfig.Functions.ModeSpawnGetRandomPointFunc(p, &MapConfig.DefaultSpawnParams[pvars->MobVars.SpawnParamsIdx]);
     vector_copy(moby->Position, p);
     vector_copy(pvars->MobVars.MoveVars.NextPosition, p);
     vector_copy(pvars->MobVars.MoveVars.LastPosition, p);
@@ -1404,10 +1404,10 @@ void reactorSpawnMinion(Moby* moby, float radius)
   }
   
   // spawn
-  if (MapConfig.ModeCreateMobFunc)
-    MapConfig.ModeCreateMobFunc(reactorMinionSpawnParamIdx, position, moby->Rotation[2], -1, 0, &spawnParams->Config);
+  if (MapConfig.Functions.ModeCreateMobFunc)
+    MapConfig.Functions.ModeCreateMobFunc(reactorMinionSpawnParamIdx, position, moby->Rotation[2], -1, 0, &spawnParams->Config);
   else
-    MapConfig.OnMobCreateFunc(reactorMinionSpawnParamIdx, position, moby->Rotation[2], -1, 0, &spawnParams->Config);
+    MapConfig.Functions.OnMobCreateFunc(reactorMinionSpawnParamIdx, position, moby->Rotation[2], -1, 0, &spawnParams->Config);
 }
 
 //--------------------------------------------------------------------------

--- a/codegen/rc4/survival/mysterybox.c
+++ b/codegen/rc4/survival/mysterybox.c
@@ -856,8 +856,8 @@ int mboxHandleEvent_GivePlayer(Moby* moby, GuberEvent* event)
         }
         case MYSTERY_BOX_ITEM_UPGRADE_WEAPON:
         {
-          if (MapConfig.UpgradePlayerWeaponFunc) {
-            MapConfig.UpgradePlayerWeaponFunc(playerId, random, 0);
+          if (MapConfig.Functions.ModeUpgradePlayerWeaponFunc) {
+            MapConfig.Functions.ModeUpgradePlayerWeaponFunc(playerId, random, 0);
           }
           break;
         }

--- a/codegen/rc4/survival/stackbox.c
+++ b/codegen/rc4/survival/stackbox.c
@@ -119,7 +119,8 @@ int sboxGetStackableCost(int playerId, enum StackableItemId item)
 {
   if (!MapConfig.State) return 0;
 
-  return MapConfig.BakedConfig->StackboxBaseCost + playerGetStackableCount(playerId, (int)item) * MapConfig.BakedConfig->StackboxCostPerPerk;
+
+  return bakedConfig.StackboxBaseCost + playerGetStackableCount(playerId, (int)item) * bakedConfig.StackboxCostPerPerk;
 }
 
 //--------------------------------------------------------------------------

--- a/codegen/rc4/survival/survival.c
+++ b/codegen/rc4/survival/survival.c
@@ -1,9 +1,9 @@
 /***************************************************
  * FILENAME :		map.c
- * 
+ *
  * DESCRIPTION :
  * 		Custom map logic for Survival.
- * 		
+ *
  * AUTHOR :			Daniel "Dnawrkshp" Gerendasy
  */
 
@@ -35,6 +35,8 @@
 #include "messageid.h"
 #include "game.h"
 #include "mob.h"
+#include "config.h"
+#include "interop.h"
 #include "pathfind.h"
 #include "maputils.h"
 #include "upgrade.h"
@@ -51,12 +53,11 @@
 #define MAP_BASE_COMPLEXITY (5000)
 #endif
 
-struct Guber* mapGetGuber(Moby* moby);
-void mapHandleEvent(Moby* moby, GuberEvent* event);
+struct Guber *mapGetGuber(Moby *moby);
+void mapHandleEvent(Moby *moby, GuberEvent *event);
 
 void mobInit(void);
 void mobTick(void);
-void configInit(void);
 void pathTick(void);
 
 #if STACKABLES
@@ -69,18 +70,15 @@ void blessingsInit(void);
 void blessingsTick(void);
 #endif
 
-void stackableOnMobKilled(Moby* moby, int killedByPlayerId, int killedByWeaponId);
+void stackableOnMobKilled(Moby *moby, int killedByPlayerId, int killedByWeaponId);
 
 void frameTick(void);
 int createMob(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, int spawnFlags, struct MobConfig *config);
-void mapOnMobKilled(Moby* moby, int killedByPlayerId, int killedByWeaponId);
-int mapConsiderMobSpawnPoint(struct MobSpawnParams* mobSpawnParams, VECTOR position, float yaw, Player* targetPlayer);
-int mapGetSpawnPoints(int** outSpawnPointIndices);
-int mapCanSpawnMobs(void);
 
 char LocalPlayerStrBuffer[GAME_MAX_LOCALS][64];
 
-typedef struct HudBoss_CommonData { // 0x38
+typedef struct HudBoss_CommonData
+{ // 0x38
 	/* 0x00 */ int iShown;
 	/* 0x04 */ int iState;
 	/* 0x08 */ float fHP;
@@ -99,629 +97,771 @@ typedef struct HudBoss_CommonData { // 0x38
 } HudBoss_CommonData_t;
 
 // set by map
-extern int mobAllowedCuboidIdx;
-extern int mobSpawnPointsAreaIdx;
-extern SurvivalBakedConfig_t bakedConfig;
 struct SurvivalMapConfig MapConfig __attribute__((section(".config"))) = {
-  .Magic = MAP_CONFIG_MAGIC,
-	.State = NULL,
-  .BakedConfig = &bakedConfig,
-  .OnFrameTickFunc = &frameTick,
-  .OnMobCreateFunc = &createMob,
-  .OnMobKilledFunc = &mapOnMobKilled,
-  .CanSpawnMobsFunc = &mapCanSpawnMobs,
-  .GetSpawnPointsFunc = &mapGetSpawnPoints,
-  .ConsiderMobSpawnPointFunc = &mapConsiderMobSpawnPoint
+		.Magic = MAP_CONFIG_MAGIC,
+		.State = NULL,
+		.Functions.OnFrameTickFunc = &frameTick,
+		.Functions.OnMobCreateFunc = &createMob,
+		.Functions.OnMobKilledFunc = &mapOnMobKilled,
+		.Functions.CanSpawnMobsFunc = &mapCanSpawnMobs,
+		.Functions.GetSpawnPointsFunc = &mapGetSpawnPoints,
+		.Functions.ConsiderMobSpawnPointFunc = &mapConsiderMobSpawnPoint,
+		.Functions.GetDifficultyMultiplierFunc = &mapGetDifficultyMultiplier,
+		.Functions.GetBoltMultiplierFunc = &mapGetBoltMultiplier,
+		.Functions.GetXpMultiplierFunc = &mapGetXpMultiplier,
+		.Functions.GetBoltRankMultiplierFunc = &mapGetBoltRankMultiplier,
+		.Functions.GetSpawnDistanceMultiplierFunc = &mapGetSpawnDistanceMultiplier,
+		.Functions.GetWeaponPickupCooldownMultiplierFunc = &mapGetWeaponPickupCooldownMultiplier,
+		.Functions.GetBakedSpawnPointsFunc = &mapGetBakedSpawnPoints,
+		.Functions.CanPrestigePlayerWeaponFunc = &mapCanPrestigePlayerWeapon,
+		.Functions.GetPrestigePlayerWeaponCostFunc = &mapGetPrestigePlayerWeaponCost,
+		.Functions.CanUpgradePlayerWeaponFunc = &mapCanUpgradePlayerWeapon,
+		.Functions.GetUpgradePlayerWeaponCostFunc = &mapGetUpgradePlayerWeaponCost,
+		.Functions.GetXpForNextTokenFunc = &mapGetXpForNextToken,
 };
 
 //--------------------------------------------------------------------------
 int mapSpawnMob(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, int spawnFlags)
 {
-  // increment # mobs to spawn
-  if (MapConfig.State && spawnFromUID < 0) {
-    MapConfig.State->RoundMaxMobCount += 1;
-  }
+	// increment # mobs to spawn
+	if (MapConfig.State && spawnFromUID < 0)
+	{
+		MapConfig.State->RoundMaxMobCount += 1;
+	}
 
-  if (!gameAmIHost()) return;
+	if (!gameAmIHost())
+		return;
 
-  struct MobConfig* config = &MapConfig.DefaultSpawnParams[spawnParamsIdx].Config;
+	struct MobConfig *config = &MapConfig.DefaultSpawnParams[spawnParamsIdx].Config;
 
-  // spawn
-  if (MapConfig.ModeCreateMobFunc)
-    return MapConfig.ModeCreateMobFunc(spawnParamsIdx, position, yaw, spawnFromUID, spawnFlags, config);
-  else
-    return MapConfig.OnMobCreateFunc(spawnParamsIdx, position, yaw, spawnFromUID, spawnFlags, config);
-}
-
-//--------------------------------------------------------------------------
-void mapOnMobKilled(Moby* moby, int killedByPlayerId, int killedByWeaponId)
-{
-#if STACKABLES
-  stackableOnMobKilled(moby, killedByPlayerId, killedByWeaponId);
-#endif
-
-#if SOULCOLLECTOR
-  soulcollectorOnSoul(moby->Position, killedByPlayerId);
-#endif
-
-#ifdef AMMO_DROP_PROBABILITY
-  Player* player = playerGetAll()[killedByPlayerId];
-  if (playerIsValid(player) && player->IsLocal && randRange(0, 1) < AMMO_DROP_PROBABILITY) {
-    ammodropCreateAt(moby);
-  }
-#endif
-}
-
-//--------------------------------------------------------------------------
-int mapCanSpawnMobs(void)
-{
-#if DEBUG_MANUAL_SPAWNING
-  return 0;
-#endif
-
-  return 1;
+	// spawn
+	if (MapConfig.Functions.ModeCreateMobFunc)
+		return MapConfig.Functions.ModeCreateMobFunc(spawnParamsIdx, position, yaw, spawnFromUID, spawnFlags, config);
+	else
+		return MapConfig.Functions.OnMobCreateFunc(spawnParamsIdx, position, yaw, spawnFromUID, spawnFlags, config);
 }
 
 //--------------------------------------------------------------------------
 void mapReturnPlayersToMap(void)
 {
-  int i;
-  VECTOR p,r,o;
+	int i;
+	VECTOR p, r, o;
+	float deathHeight = maxf(1, gameGetDeathHeight()) + 1; // if death height is 0, use 1
 
-  for (i = 0; i < GAME_MAX_LOCALS; ++i) {
-    Player* player = playerGetFromSlot(i);
-    if (!player || !player->SkinMoby) continue;
+	for (i = 0; i < GAME_MAX_LOCALS; ++i)
+	{
+		Player *player = playerGetFromSlot(i);
+		if (!player || !player->SkinMoby)
+			continue;
 
-    // if we're under the map, teleport back up
-    if (player->PlayerPosition[2] < (gameGetDeathHeight() + 1)) {
-      
-      // move back to player start
-      playerGetSpawnpoint(player, p, r, 0);
-      vector_fromyaw(o, (player->PlayerId / (float)GAME_MAX_PLAYERS) * MATH_TAU - MATH_PI);
-      vector_scale(o, o, 2.5);
-      vector_add(p, p, o);
-      playerSetPosRot(player, p, r);
-      playerSetHealth(player, maxf(0, player->Health - player->MaxHealth*0.5));
-    }
-  }
+		// if we're under the map, teleport back up
+		if (player->PlayerPosition[2] < deathHeight)
+		{
+			// move back to player start
+			playerTeleportToSpawn(player, 0.5);
+		}
+	}
 }
 
 //--------------------------------------------------------------------------
-void mobForceIntoMapBounds(Moby* moby)
+void mobForceIntoMapBounds(Moby *moby)
 {
-  if (!moby)
-    return;
-    
-  int i;
-	struct MobPVar* pvars = (struct MobPVar*)moby->PVar;
+	if (!moby)
+		return;
 
-  // if no cuboid defined, restrict mobs to moby grid range
-  if (mobAllowedCuboidIdx < 0) {
-    VECTOR min = { 0, 0, 0, 0 };
-    VECTOR max = { 1024, 1024, 1024, 0 };
-    for (i = 0; i < 3; ++i) {
-      if (moby->Position[i] < min[i]) {
-        moby->Position[i] = min[i];
-        pvars->MobVars.Respawn = 1;
-        break;
-      }
-      else if (moby->Position[i] > max[i]) {
-        moby->Position[i] = max[i];
-        pvars->MobVars.Respawn = 1;
-        break;
-      }
-    }
-    return;
-  }
-  
-  SpawnPoint* cuboid = spawnPointGet(mobAllowedCuboidIdx);
-  VECTOR rel;
-  if (spawnPointIsPointInside(cuboid, moby->Position, rel)) return;
+	int i;
+	struct MobPVar *pvars = (struct MobPVar *)moby->PVar;
 
-  // clamp position & respawn
-  rel[0] = clamp(rel[0], -1, 1);
-  rel[1] = clamp(rel[1], -1, 1);
-  rel[2] = clamp(rel[2], -1, 1);
-  vector_apply(moby->Position, rel, cuboid->M0);
-  pvars->MobVars.Respawn = 1;
+	// if no cuboid defined, restrict mobs to moby grid range
+	if (mobAllowedCuboidIdx < 0)
+	{
+		VECTOR min = {0, 0, 0, 0};
+		VECTOR max = {1024, 1024, 1024, 0};
+		for (i = 0; i < 3; ++i)
+		{
+			if (moby->Position[i] < min[i])
+			{
+				moby->Position[i] = min[i];
+				pvars->MobVars.Respawn = 1;
+				break;
+			}
+			else if (moby->Position[i] > max[i])
+			{
+				moby->Position[i] = max[i];
+				pvars->MobVars.Respawn = 1;
+				break;
+			}
+		}
+		return;
+	}
+
+	SpawnPoint *cuboid = spawnPointGet(mobAllowedCuboidIdx);
+	VECTOR rel;
+	if (spawnPointIsPointInside(cuboid, moby->Position, rel))
+		return;
+
+	// clamp position & respawn
+	rel[0] = clamp(rel[0], -1, 1);
+	rel[1] = clamp(rel[1], -1, 1);
+	rel[2] = clamp(rel[2], -1, 1);
+	vector_apply(moby->Position, rel, cuboid->M0);
+	pvars->MobVars.Respawn = 1;
 }
 
 //--------------------------------------------------------------------------
-int mapPathCanBeSkippedForTarget(Moby* moby)
+int mapPathCanBeSkippedForTarget(Moby *moby)
 {
-  return 1;
+	return 1;
 }
 
 //--------------------------------------------------------------------------
 int createMob(int spawnParamsIdx, VECTOR position, float yaw, int spawnFromUID, int spawnFlags, struct MobConfig *config)
 {
-  if (spawnParamsIdx < 0 || spawnParamsIdx >= MapConfig.DefaultSpawnParamsCount) {
-    DPRINTF("unhandled create spawnParamsIdx %d\\n", spawnParamsIdx);
-    return 0;
-  }
+	if (spawnParamsIdx < 0 || spawnParamsIdx >= MapConfig.DefaultSpawnParamsCount)
+	{
+		DPRINTF("unhandled create spawnParamsIdx %d\\n", spawnParamsIdx);
+		return 0;
+	}
 
-  //struct MobSpawnParams* spawnParams = &MapConfig.DefaultSpawnParams[spawnParamsIdx];
-  //if (spawnParams->MobCreate)
-  //  return spawnParams->MobCreate(spawnParamsIdx, position, yaw, spawnFromUID, spawnFlags, config);
+	// struct MobSpawnParams* spawnParams = &MapConfig.DefaultSpawnParams[spawnParamsIdx];
+	// if (spawnParams->MobCreate)
+	//   return spawnParams->MobCreate(spawnParamsIdx, position, yaw, spawnFromUID, spawnFlags, config);
 
-  return mobCreate(spawnParamsIdx, position, yaw, spawnFromUID, spawnFlags, config);
+	return mobCreate(spawnParamsIdx, position, yaw, spawnFromUID, spawnFlags, config);
 }
 
 //--------------------------------------------------------------------------
-void addBlip(Moby* moby, int type, int team, int life)
+void addBlip(Moby *moby, int type, int team, int life)
 {
-  if (!moby) return;
+	if (!moby)
+		return;
 
-  // add blip
-  int blipId = radarGetBlipIndex(moby);
-  if (blipId >= 0)
-  {
-    RadarBlip * blip = radarGetBlips() + blipId;
-    blip->X = moby->Position[0];
-    blip->Y = moby->Position[1];
-    blip->Life = life;
-    blip->Type = type;
-    blip->Team = team;
-  }
+	// add blip
+	int blipId = radarGetBlipIndex(moby);
+	if (blipId >= 0)
+	{
+		RadarBlip *blip = radarGetBlips() + blipId;
+		blip->X = moby->Position[0];
+		blip->Y = moby->Position[1];
+		blip->Life = life;
+		blip->Type = type;
+		blip->Team = team;
+	}
 }
 
 //--------------------------------------------------------------------------
 void randomizeWeaponPickups(void)
 {
-  int i,j;
-  GameOptions* gameOptions = gameGetOptions();
-  char wepCounts[9];
-  char wepEnabled[17];
-  int pickupCount = 0;
-  int pickupOptionCount = 0;
-  memset(wepEnabled, 0, sizeof(wepEnabled));
-  memset(wepCounts, 0, sizeof(wepCounts));
+	int i, j;
+	GameOptions *gameOptions = gameGetOptions();
+	char wepCounts[9];
+	char wepEnabled[17];
+	int pickupCount = 0;
+	int pickupOptionCount = 0;
+	memset(wepEnabled, 0, sizeof(wepEnabled));
+	memset(wepCounts, 0, sizeof(wepCounts));
 
-  if (gameOptions->WeaponFlags.DualVipers) { wepEnabled[2] = 1; pickupOptionCount++; }
-  if (gameOptions->WeaponFlags.MagmaCannon) { wepEnabled[3] = 1; pickupOptionCount++; }
-  if (gameOptions->WeaponFlags.Arbiter) { wepEnabled[4] = 1; pickupOptionCount++; }
-  if (gameOptions->WeaponFlags.FusionRifle) { wepEnabled[5] = 1; pickupOptionCount++; }
-  if (gameOptions->WeaponFlags.MineLauncher) { wepEnabled[6] = 1; pickupOptionCount++; }
-  if (gameOptions->WeaponFlags.B6) { wepEnabled[7] = 1; pickupOptionCount++; }
-  if (gameOptions->WeaponFlags.Holoshield) { wepEnabled[16] = 1; pickupOptionCount++; }
-  if (gameOptions->WeaponFlags.Flail) { wepEnabled[12] = 1; pickupOptionCount++; }
-  if (gameOptions->WeaponFlags.Chargeboots && gameOptions->GameFlags.MultiplayerGameFlags.SpawnWithChargeboots == 0) { wepEnabled[13] = 1; pickupOptionCount++; }
+	if (gameOptions->WeaponFlags.DualVipers)
+	{
+		wepEnabled[2] = 1;
+		pickupOptionCount++;
+	}
+	if (gameOptions->WeaponFlags.MagmaCannon)
+	{
+		wepEnabled[3] = 1;
+		pickupOptionCount++;
+	}
+	if (gameOptions->WeaponFlags.Arbiter)
+	{
+		wepEnabled[4] = 1;
+		pickupOptionCount++;
+	}
+	if (gameOptions->WeaponFlags.FusionRifle)
+	{
+		wepEnabled[5] = 1;
+		pickupOptionCount++;
+	}
+	if (gameOptions->WeaponFlags.MineLauncher)
+	{
+		wepEnabled[6] = 1;
+		pickupOptionCount++;
+	}
+	if (gameOptions->WeaponFlags.B6)
+	{
+		wepEnabled[7] = 1;
+		pickupOptionCount++;
+	}
+	if (gameOptions->WeaponFlags.Holoshield)
+	{
+		wepEnabled[16] = 1;
+		pickupOptionCount++;
+	}
+	if (gameOptions->WeaponFlags.Flail)
+	{
+		wepEnabled[12] = 1;
+		pickupOptionCount++;
+	}
+	if (gameOptions->WeaponFlags.Chargeboots && gameOptions->GameFlags.MultiplayerGameFlags.SpawnWithChargeboots == 0)
+	{
+		wepEnabled[13] = 1;
+		pickupOptionCount++;
+	}
 
-  if (pickupOptionCount > 0) {
-    Moby* moby = mobyListGetStart();
-    Moby* mEnd = mobyListGetEnd();
+	if (pickupOptionCount > 0)
+	{
+		Moby *moby = mobyListGetStart();
+		Moby *mEnd = mobyListGetEnd();
 
-    while (moby < mEnd) {
-      if (moby->OClass == MOBY_ID_WEAPON_PICKUP && moby->PVar) {
-        
-        int target = pickupCount / pickupOptionCount;
-        int gadgetId = 1;
-        if (target < 3) {
-          do { j = rand(pickupOptionCount); } while (wepCounts[j] != target);
+		while (moby < mEnd)
+		{
+			if (moby->OClass == MOBY_ID_WEAPON_PICKUP && moby->PVar)
+			{
 
-          ++wepCounts[j];
+				int target = pickupCount / pickupOptionCount;
+				int gadgetId = 1;
+				if (target < 3)
+				{
+					do
+					{
+						j = rand(pickupOptionCount);
+					} while (wepCounts[j] != target);
 
-          i = -1;
-          do
-          {
-            ++i;
-            if (wepEnabled[i])
-              --j;
-          } while (j >= 0);
+					++wepCounts[j];
 
-          gadgetId = i;
-        }
+					i = -1;
+					do
+					{
+						++i;
+						if (wepEnabled[i])
+							--j;
+					} while (j >= 0);
 
-        // set pickup
-        ((void (*)(Moby*, int))0x0043A370)(moby, gadgetId);
+					gadgetId = i;
+				}
 
-        ++pickupCount;
-      }
+				// set pickup
+				((void (*)(Moby *, int))0x0043A370)(moby, gadgetId);
 
-      ++moby;
-    }
-  }
+				++pickupCount;
+			}
+
+			++moby;
+		}
+	}
 }
 
 //--------------------------------------------------------------------------
 void updateBossMeter(void)
 {
-  static float lastHealth = -1;
-  HudBoss_CommonData_t* hudBossData = (HudBoss_CommonData_t*)0x00310400;
-  int i;
-  Moby* bossMoby = NULL;
+	static float lastHealth = -1;
+	HudBoss_CommonData_t *hudBossData = (HudBoss_CommonData_t *)0x00310400;
+	int i;
+	Moby *bossMoby = NULL;
 
-  if (MapConfig.State)
-    bossMoby = MapConfig.State->BossMoby;
+	if (MapConfig.State)
+		bossMoby = MapConfig.State->BossMoby;
 
-  // show/hide boss meter
-  for (i = 0; i < GAME_MAX_LOCALS; ++i) {
-    PlayerHUDFlags* hud = hudGetPlayerFlags(i);
-    if (hud) {
-      hud->Flags.Meter = bossMoby ? 1 : 0;
-    }
-  }
+	// show/hide boss meter
+	for (i = 0; i < GAME_MAX_LOCALS; ++i)
+	{
+		PlayerHUDFlags *hud = hudGetPlayerFlags(i);
+		if (hud)
+		{
+			hud->Flags.Meter = bossMoby ? 1 : 0;
+		}
+	}
 
-  if (!bossMoby) return;
-  struct MobPVar* pvars = (struct MobPVar*)bossMoby->PVar;
-  float health = pvars->MobVars.Health / pvars->MobVars.Config.MaxHealth;
+	if (!bossMoby)
+		return;
+	struct MobPVar *pvars = (struct MobPVar *)bossMoby->PVar;
+	float health = pvars->MobVars.Health / pvars->MobVars.Config.MaxHealth;
 
-  // update meter and icon
-  hudBossData->fHP = health;
+	// update meter and icon
+	hudBossData->fHP = health;
 
-  // refresh on health change
-  if (lastHealth != health) {
-    lastHealth = health;
-    hudBossData->bUpdate = 1;
-  }
+	// refresh on health change
+	if (lastHealth != health)
+	{
+		lastHealth = health;
+		hudBossData->bUpdate = 1;
+	}
 
-  // set boss image to reactor sprite
-  u32 id = hudPanelGetElement((void*)0x222b18, 6);
-  struct HUDWidgetRectangleObject* bossImgRectObject = (struct HUDWidgetRectangleObject*)hudCanvasGetObject(hudGetCanvas(4), id);
-  if (bossImgRectObject) ((void (*)(u32, u32))0x005ca3e8)(bossImgRectObject, MapConfig.DefaultSpawnParams[pvars->MobVars.SpawnParamsIdx].BossTexUid /*0x75AF + 3*/);
+	// set boss image to reactor sprite
+	u32 id = hudPanelGetElement((void *)0x222b18, 6);
+	struct HUDWidgetRectangleObject *bossImgRectObject = (struct HUDWidgetRectangleObject *)hudCanvasGetObject(hudGetCanvas(4), id);
+	if (bossImgRectObject)
+		((void (*)(u32, u32))0x005ca3e8)(bossImgRectObject, MapConfig.DefaultSpawnParams[pvars->MobVars.SpawnParamsIdx].BossTexUid /*0x75AF + 3*/);
+}
+
+//--------------------------------------------------------------------------
+void setWeaponPickupRespawnTime(void)
+{
+	int pickupOffsets[GAME_MAX_PLAYERS] = {0, 0, 5, 10, 12, 14, 16, 18, 21, 24};
+	GameSettings *gameSettings = gameGetSettings();
+
+	// compute pickup respawn time in ms
+	int playerCountAtStart = (gameSettings->PlayerCountAtStart <= 0 ? 1 : gameSettings->PlayerCountAtStart) - 1;
+	int respawnTimeOffset = pickupOffsets[playerCountAtStart];
+
+	Moby *moby = mobyListGetStart();
+	Moby *mEnd = mobyListGetEnd();
+
+	while (moby < mEnd)
+	{
+		if (moby->OClass == MOBY_ID_WEAPON_PICKUP && moby->PVar)
+		{
+
+			// hide if wrench
+			// wrenches are set as pickup id when we've reached the max number of
+			// pickups per gadget
+			int gadgetId = *(int *)moby->PVar;
+			int slotId = weaponIdToSlot(gadgetId) - 1;
+			if (gadgetId == 1)
+			{
+				moby->Position[2] = 0;
+			}
+			else if (slotId >= 0 && slotId < 8)
+			{
+				int weaponBaseRespawnTime = 30;
+
+				// otherwise set cooldown by configuration
+				int ms = (weaponBaseRespawnTime - respawnTimeOffset) * mapGetWeaponPickupCooldownMultiplier() * TIME_SECOND;
+				POKE_U32((u32)moby->PVar + 0x0C, ms);
+			}
+		}
+		++moby;
+	}
+}
+
+//--------------------------------------------------------------------------
+int mapBlockPlayerUseTeleporter(Moby *moby, Player *player)
+{
+	// pointer to player is in $s1
+	asm volatile(
+			".set noreorder;\n"
+			"move %0, $s1"
+			: : "r"(player));
+
+	return 0;
+}
+
+//--------------------------------------------------------------------------
+void playerDamageAndTeleportToSpawn(Player *player, int toState, int bTransAnim, int bForce, int bFall)
+{
+	// check if toState is a death state
+	// and if so tp to spawn and subtract health
+	// otherwise pass state transition to handler
+	if (player->Health <= 0 || !playerStateIsDead(toState))
+	{
+		playerGetVTable(player)->UpdateState(player, toState, bTransAnim, bForce, bFall);
+		return;
+	}
+
+	playerTeleportToSpawn(player, 0.5);
+}
+
+//--------------------------------------------------------------------------
+void playerDrownAndTeleportToSpawn(Player *player)
+{
+	playerTeleportToSpawn(player, 0.5);
+}
+
+//--------------------------------------------------------------------------
+void playerOnPushedIntoWall(Player *player)
+{
+	if (!player || !player->SkinMoby || !player->PlayerMoby)
+		return;
+
+	// this is also called when a player drowns (sometimes)
+	if (player->PlayerState == PLAYER_STATE_QUICKSAND_SINK)
+	{
+		playerDrownAndTeleportToSpawn(player);
+		return;
+	}
+
+	// push mobs away
+	mobReactToExplosionAt(player->PlayerId, player->PlayerPosition, 1, 8, 1);
+
+	// move player out of clipped wall
+	// using lastGoodPos doesn't always return us to before the clip
+	if (player->IsLocal)
+	{
+		playerSetPosRot(player, player->Ground.lastGoodPos, player->PlayerRotation);
+	}
 }
 
 //--------------------------------------------------------------------------
 void frameTick(void)
 {
 #if STACKABLES
-  sboxFrameTick();
+	sboxFrameTick();
 #endif
 
 #if SOULCOLLECTOR
-  soulcollectorFrameUpdate();
+	soulcollectorFrameUpdate();
 #endif
 
-  //char buf[32];
-  //snprintf(buf, sizeof(buf), "%d", mobyGetNumSpawnableMobys());
-  //gfxHelperDrawText(5, SCREEN_HEIGHT - 5, 0, 0, 1, 0x80FFFFFF, buf, -1, TEXT_ALIGN_BOTTOMLEFT, COMMON_DZO_DRAW_NORMAL);
-}
-
-//--------------------------------------------------------------------------
-int mapConsiderMobSpawnPoint(struct MobSpawnParams* mobSpawnParams, VECTOR position, float yaw, Player* targetPlayer)
-{
-  if (!targetPlayer || !targetPlayer->PlayerMoby) return 1;
-
-  // check if we have a path to
-  // if not, don't spawn here
-  if (!pathHasRouteFromTo(pathGetClosestNodeIdx(position), pathTargetCacheGetClosestNodeIdx(targetPlayer->PlayerMoby))) {
-    return 0;
-  }
-
-  return 1;
-}
-
-//--------------------------------------------------------------------------
-int mapGetSpawnPoints(int** outSpawnPointIndices)
-{
-  Area_t area;
-  if (mobSpawnPointsAreaIdx < 0 || !areaGetArea(mobSpawnPointsAreaIdx, &area)) {
-    *outSpawnPointIndices = NULL;
-    return 0;
-  }
-
-  *outSpawnPointIndices = area.Cuboids;
-  return area.CuboidCount;
-}
-
-//--------------------------------------------------------------------------
-int mapBlockPlayerUseTeleporter(Moby* moby, Player* player)
-{
-	// pointer to player is in $s1
-	asm volatile (
-    ".set noreorder;\n"
-		"move %0, $s1"
-		: : "r" (player)
-	);
-
-  return 0;
+	// char buf[32];
+	// snprintf(buf, sizeof(buf), "%d", mobyGetNumSpawnableMobys());
+	// gfxHelperDrawText(5, SCREEN_HEIGHT - 5, 0, 0, 1, 0x80FFFFFF, buf, -1, TEXT_ALIGN_BOTTOMLEFT, COMMON_DZO_DRAW_NORMAL);
 }
 
 //--------------------------------------------------------------------------
 void survivalDebugManualSpawn(void)
 {
-  static int manSpawnMobId = 0;
-  if (MapConfig.DefaultSpawnParamsCount <= 0) return; // no mobs
-  if (!localPlayerHasInput()) return;
+	static int manSpawnMobId = 0;
+	if (MapConfig.DefaultSpawnParamsCount <= 0)
+		return; // no mobs
+	if (!localPlayerHasInput())
+		return;
 
-  Player* localPlayer = playerGetFromSlot(0);
-  if (!playerIsValid(localPlayer)) return;
-  
-  // check for destroy all mobs
-  if (MapConfig.ModeMobNukeFunc && padGetButtonDown(0, PAD_UP) > 0) {
-    MapConfig.ModeMobNukeFunc(-1);
-  }
+	Player *localPlayer = playerGetFromSlot(0);
+	if (!playerIsValid(localPlayer))
+		return;
 
-  // nav mobs
-  int dir = 0;
-  if (padGetButtonDown(0, PAD_LEFT) > 0) {
-    dir = -1;
-  } else if (padGetButtonDown(0, PAD_RIGHT) > 0) {
-    dir = 1;
-  }
+	// check for destroy all mobs
+	if (MapConfig.Functions.ModeMobNukeFunc && padGetButtonDown(0, PAD_UP) > 0)
+	{
+		MapConfig.Functions.ModeMobNukeFunc(-1);
+	}
 
-  if (dir) {
-    manSpawnMobId = (manSpawnMobId + dir + MapConfig.DefaultSpawnParamsCount) % MapConfig.DefaultSpawnParamsCount;
-    DPRINTF("selected mob: %s (%d)\n", MapConfig.DefaultSpawnParams[manSpawnMobId].Name, manSpawnMobId);
-  }
+	// nav mobs
+	int dir = 0;
+	if (padGetButtonDown(0, PAD_LEFT) > 0)
+	{
+		dir = -1;
+	}
+	else if (padGetButtonDown(0, PAD_RIGHT) > 0)
+	{
+		dir = 1;
+	}
 
-  // check for spawn pad button
-  if (padGetButtonDown(0, PAD_DOWN) <= 0) return;
+	if (dir)
+	{
+		manSpawnMobId = (manSpawnMobId + dir + MapConfig.DefaultSpawnParamsCount) % MapConfig.DefaultSpawnParamsCount;
+		DPRINTF("selected mob: %s (%d)\n", MapConfig.DefaultSpawnParams[manSpawnMobId].Name, manSpawnMobId);
+	}
 
-  // build spawn position
-  VECTOR t;
-  VECTOR offset = {1,1,1,0};
-  vector_scale(t, offset, MapConfig.DefaultSpawnParams[manSpawnMobId].Config.CollRadius*2);
-  vector_add(t, t, localPlayer->PlayerPosition);
+	// check for spawn pad button
+	if (padGetButtonDown(0, PAD_DOWN) <= 0)
+		return;
 
-  int r = mapSpawnMob(manSpawnMobId, t, 0, -1, 0);
-  DPRINTF("manual spawn mob %s (idx %d) returned %d\n", MapConfig.DefaultSpawnParams[manSpawnMobId].Name, manSpawnMobId, r);
+	// build spawn position
+	VECTOR t;
+	VECTOR offset = {1, 1, 1, 0};
+	vector_scale(t, offset, MapConfig.DefaultSpawnParams[manSpawnMobId].Config.CollRadius * 2);
+	vector_add(t, t, localPlayer->PlayerPosition);
+
+	int r = mapSpawnMob(manSpawnMobId, t, 0, -1, 0);
+	DPRINTF("manual spawn mob %s (idx %d) returned %d\n", MapConfig.DefaultSpawnParams[manSpawnMobId].Name, manSpawnMobId, r);
 }
 
 //--------------------------------------------------------------------------
 void survivalDebugInfiniteHealth(void)
 {
-  int i;
-  for (i = 0; i < GAME_MAX_LOCALS; ++i) {
-    Player* player = playerGetFromSlot(i);
-    if (!playerIsValid(player)) continue;
+	int i;
+	for (i = 0; i < GAME_MAX_LOCALS; ++i)
+	{
+		Player *player = playerGetFromSlot(i);
+		if (!playerIsValid(player))
+			continue;
 
-    player->Health = 125;
-  }
+		player->Health = 125;
+	}
 }
 
 //--------------------------------------------------------------------------
 void survivalDebugInfiniteAmmo(void)
 {
-  GameOptions* go = gameGetOptions();
-  go->GameFlags.MultiplayerGameFlags.UnlimitedAmmo = 1;
+	GameOptions *go = gameGetOptions();
+	go->GameFlags.MultiplayerGameFlags.UnlimitedAmmo = 1;
 }
 
 //--------------------------------------------------------------------------
 void survivalDebugPayday(void)
 {
-  int i;
-  static int init = 0;
-  if (!MapConfig.State) return;
-  
-  // give max alpha mods
-  for (i = 0; i < GAME_MAX_LOCALS; ++i) {
-    Player* player = playerGetFromSlot(i);
-    if (!playerIsValid(player)) continue;
+	int i;
+	static int init = 0;
+	if (!MapConfig.State)
+		return;
 
-    GadgetBox* gbox = player->GadgetBox;
-    if (!gbox) continue;
-  
-    gbox->ModBasic[0] = 64;
-    gbox->ModBasic[1] = 64;
-    gbox->ModBasic[2] = 64;
-    gbox->ModBasic[3] = 64;
-    gbox->ModBasic[4] = 64;
-    gbox->ModBasic[5] = 64;
-    gbox->ModBasic[6] = 64;
-    gbox->ModBasic[7] = 64;
-  }
+	// give max alpha mods
+	for (i = 0; i < GAME_MAX_LOCALS; ++i)
+	{
+		Player *player = playerGetFromSlot(i);
+		if (!playerIsValid(player))
+			continue;
 
-  if (init) return;
+		GadgetBox *gbox = player->GadgetBox;
+		if (!gbox)
+			continue;
 
-  // set bolts/tokens once
-  for (i = 0; i < GAME_MAX_PLAYERS; ++i) {
-    MapConfig.State->PlayerStates[i].State.Bolts = 100000000;
-    MapConfig.State->PlayerStates[i].State.CurrentTokens = 10000;
-  }
+		gbox->ModBasic[0] = 64;
+		gbox->ModBasic[1] = 64;
+		gbox->ModBasic[2] = 64;
+		gbox->ModBasic[3] = 64;
+		gbox->ModBasic[4] = 64;
+		gbox->ModBasic[5] = 64;
+		gbox->ModBasic[6] = 64;
+		gbox->ModBasic[7] = 64;
+	}
 
-  init = 1;
+	if (init)
+		return;
+
+	// set bolts/tokens once
+	for (i = 0; i < GAME_MAX_PLAYERS; ++i)
+	{
+		MapConfig.State->PlayerStates[i].State.Bolts = 100000000;
+		MapConfig.State->PlayerStates[i].State.CurrentTokens = 10000;
+	}
+
+	init = 1;
 }
 
 //--------------------------------------------------------------------------
 void survivalDebugMoonjump(void)
 {
-  int i;
-  for (i = 0; i < GAME_MAX_LOCALS; ++i) {
-    Player* player = playerGetFromSlot(i);
-    if (!playerIsValid(player)) continue;
-    if (padGetButton(i, PAD_CROSS) <= 0) continue;
+	int i;
+	for (i = 0; i < GAME_MAX_LOCALS; ++i)
+	{
+		Player *player = playerGetFromSlot(i);
+		if (!playerIsValid(player))
+			continue;
+		if (padGetButton(i, PAD_CROSS) <= 0)
+			continue;
 
-    player->Velocity[2] = 0.125;
-  }
+		player->Velocity[2] = 0.125;
+	}
 }
 
 //--------------------------------------------------------------------------
 void survivalDebugStartRound(int roundNumber)
 {
-  struct SurvivalState* state = MapConfig.State;
-  if (!state) return;
-  if (roundNumber <= 1) return; // no round skip
+	struct SurvivalState *state = MapConfig.State;
+	if (!state)
+		return;
+	if (roundNumber <= 1)
+		return; // no round skip
 
-  static int init = 0;
-  if (init == 2) return;
-  if (init == 1) {
-      
-    // set round to immediately end after it is initialized by the game mode
-    if (state->RoundMaxMobCount) {
-      state->MobStats.TotalSpawnedThisRound = state->RoundMaxMobCount;
-      init = 2;
-    }
+	static int init = 0;
+	if (init == 2)
+		return;
+	if (init == 1)
+	{
 
-    return;
-  }
+		// set round to immediately end after it is initialized by the game mode
+		if (state->RoundMaxMobCount)
+		{
+			state->MobStats.TotalSpawnedThisRound = state->RoundMaxMobCount;
+			init = 2;
+		}
 
-  // set to round prior to target round number
-  // once the game initializes the round we'll force it to end
-  // starting the target round (with the interum period)
-  state->RoundNumber = roundNumber - 2;
-  state->RoundMaxMobCount = 0;
+		return;
+	}
 
-  // set initial bolt/token
-  // also bump health upgrades up a bit for testing convenience
-  int j;
-  for (j = 0; j < GAME_MAX_PLAYERS; ++j) {
-    state->PlayerStates[j].State.Bolts = powf(1.225, roundNumber) * 10000;
-    state->PlayerStates[j].State.CurrentTokens = roundNumber * 5;
-    state->PlayerStates[j].State.Upgrades[UPGRADE_HEALTH] = roundNumber;
-  }
+	// set to round prior to target round number
+	// once the game initializes the round we'll force it to end
+	// starting the target round (with the interum period)
+	state->RoundNumber = roundNumber - 2;
+	state->RoundMaxMobCount = 0;
 
-  // iterate each round
-  int i;
-  for (i = 0; i < state->RoundNumber; ++i) {
-    state->MobStats.TotalSpawned += MAX_MOBS_BASE + (int)(MAX_MOBS_ROUND_WEIGHT * (1 + i));
-  }
+	// set initial bolt/token
+	// also bump health upgrades up a bit for testing convenience
+	int j;
+	for (j = 0; j < GAME_MAX_PLAYERS; ++j)
+	{
+		state->PlayerStates[j].State.Bolts = powf(1.225, roundNumber) * 10000;
+		state->PlayerStates[j].State.CurrentTokens = roundNumber * 5;
+		state->PlayerStates[j].State.Upgrades[UPGRADE_HEALTH] = roundNumber;
+	}
 
-  DPRINTF("Skipped to Round #%d with %d mobs spawned\n", state->RoundNumber + 1, state->MobStats.TotalSpawned);
-  init = 1;
+	// iterate each round
+	int i;
+	for (i = 0; i < state->RoundNumber; ++i)
+	{
+		state->MobStats.TotalSpawned += MAX_MOBS_BASE + (int)(MAX_MOBS_ROUND_WEIGHT * (1 + i));
+	}
+
+	DPRINTF("Skipped to Round #%d with %d mobs spawned\n", state->RoundNumber + 1, state->MobStats.TotalSpawned);
+	init = 1;
 }
 
 //--------------------------------------------------------------------------
 void survivalInit(void)
 {
-  static int initialized = 0;
-  if (initialized)
-    return;
+	static int initialized = 0;
+	if (initialized)
+		return;
 
-  MapConfig.Magic = MAP_CONFIG_MAGIC;
+	MapConfig.Magic = MAP_CONFIG_MAGIC;
 
-  mapApplyFixes();
-  poolInit();
-  mboxInit();
-  mobInit();
-  ammosupplyInit();
-  configInit();
-  upgradeInit();
-  dropInit();
-  bboxInit();
-  demonbellInit();
+	mapApplyFixes();
+	poolInit();
+	mboxInit();
+	mobInit();
+	ammosupplyInit();
+	configInit();
+	upgradeInit();
+	dropInit();
+	bboxInit();
+	demonbellInit();
 #if STACKABLES
-  sboxInit();
-  stackableInit();
+	sboxInit();
+	stackableInit();
 #endif
 #if GAMBITS
-  gambitsInit();
+	gambitsInit();
 #endif
 #if BLESSINGS
-  blessingsInit();
+	blessingsInit();
 #endif
 #if RANDOMIZE_WEAPONS_AT_START
-  randomizeWeaponPickups();
+	randomizeWeaponPickups();
 #endif
 #ifdef AMMO_DROP_PROBABILITY
-  ammodropInit();
+	ammodropInit();
 #endif
 
-  // disable jump pad effect
-  POKE_U32(0x0042608C, 0);
+	// disable jump pad effect
+	POKE_U32(0x0042608C, 0);
 
-  // have moby 0x1BC6 use glowColor for particle color
-  // for reactor fire effect
-  POKE_U32(0x004171D8, 0x8FA80070);
-  POKE_U32(0x00417200, 0x8D080060);
+	// have moby 0x1BC6 use glowColor for particle color
+	// for reactor fire effect
+	POKE_U32(0x004171D8, 0x8FA80070);
+	POKE_U32(0x00417200, 0x8D080060);
 
-  // enable teleporter for everyone
-  HOOK_JAL(0x003dfd18, &mapBlockPlayerUseTeleporter);
-  POKE_U32(0x003dfd1c, 0x0240202D);
-  //POKE_U32(0x003DFD20, 0x10000006);
-  POKE_U32(0x003DFD6C, 0x00000000);
+	// enable teleporter for everyone
+	HOOK_JAL(0x003dfd18, &mapBlockPlayerUseTeleporter);
+	POKE_U32(0x003dfd1c, 0x0240202D);
+	// POKE_U32(0x003DFD20, 0x10000006);
+	POKE_U32(0x003DFD6C, 0x00000000);
 
-  DPRINTF("path %08X end %08X\n", (u32)&MOB_PATHFINDING_PATHS, (u32)&MOB_PATHFINDING_PATHS + (MOB_PATHFINDING_PATHS_MAX_PATH_LENGTH * MOB_PATHFINDING_NODES_COUNT * MOB_PATHFINDING_NODES_COUNT));
+	// patch mobs pushing you into walls and killing you
+	POKE_U32(0x005e4188, 0);
+	POKE_U32(0x005e419c, 0);
+	HOOK_JAL(0x005e41bc, &playerOnPushedIntoWall);
 
-  initialized = 1;
+	// if a player dies from being stuck or drowning
+	// teleport player to spawn and damage
+	POKE_U32(0x0060adb4, 0);
+	HOOK_JAL(0x0060add4, &playerDamageAndTeleportToSpawn); // slope slide
+	POKE_U32(0x0060ade0, 0);
+	HOOK_JAL(0x005DA5AC, &playerDamageAndTeleportToSpawn); // acid drown / lava
+	POKE_U32(0x006090b8, 0);
+	HOOK_JAL(0x006090f0, &playerDrownAndTeleportToSpawn); // water drown
+
+	DPRINTF("path %08X end %08X\n", (u32)&MOB_PATHFINDING_PATHS, (u32)&MOB_PATHFINDING_PATHS + (MOB_PATHFINDING_PATHS_MAX_PATH_LENGTH * MOB_PATHFINDING_NODES_COUNT * MOB_PATHFINDING_NODES_COUNT));
+
+	initialized = 1;
 }
 
 //--------------------------------------------------------------------------
 int survivalTick(void)
 {
-  //
-  if (MapConfig.ClientsReady || !netGetDmeServerConnection())
-  {
-    mboxSpawn();
-  }
+	//
+	if (MapConfig.ClientsReady || !netGetDmeServerConnection())
+	{
+		mboxSpawn();
+	}
 
-  poolTick();
-  mobTick();
-  pathTick();
-  upgradeTick();
-  dropTick();
-  demonbellTick();
+	poolTick();
+	mobTick();
+	pathTick();
+	upgradeTick();
+	dropTick();
+	demonbellTick();
 #if STACKABLES
-  stackableTick();
+	stackableTick();
 #endif
 #if GAMBITS
-  gambitsTick();
+	gambitsTick();
 #endif
 #if BLESSINGS
-  blessingsTick();
+	blessingsTick();
 #endif
-  mapReturnPlayersToMap();
-  updateBossMeter();
+	mapReturnPlayersToMap();
+	updateBossMeter();
+	setWeaponPickupRespawnTime();
 
-  if (MapConfig.State) {
-    MapConfig.State->MapBaseComplexity = MAP_BASE_COMPLEXITY;
-  }
-  
-  // 
-  if (MapConfig.State) {
-    addBlip(MapConfig.State->BigAl, 14, TEAM_YELLOW, 31);
+	if (MapConfig.State)
+	{
+		MapConfig.State->MapBaseComplexity = MAP_BASE_COMPLEXITY;
+	}
 
-    Moby* vendorMoby = MapConfig.State->Vendor;
-    while (vendorMoby && vendorMoby->OClass == MOBY_ID_WEAPON_VENDOR) {
-      addBlip(vendorMoby, 4, TEAM_GREEN, 31);
-      ++vendorMoby;
-    }
+	//
+	if (MapConfig.State)
+	{
+		addBlip(MapConfig.State->BigAl, 14, TEAM_YELLOW, 31);
 
-    // track round completions
+		Moby *vendorMoby = MapConfig.State->Vendor;
+		while (vendorMoby && vendorMoby->OClass == MOBY_ID_WEAPON_VENDOR)
+		{
+			addBlip(vendorMoby, 4, TEAM_GREEN, 31);
+			++vendorMoby;
+		}
+
+		// track round completions
 #if GAMBITS
-    static int lastRoundCompleted = 0;
-    if (MapConfig.State->RoundEndTime && lastRoundCompleted != MapConfig.State->RoundNumber) {
-      lastRoundCompleted = MapConfig.State->RoundNumber;
-      gambitsOnRoundComplete(lastRoundCompleted);
-    }
+		static int lastRoundCompleted = 0;
+		if (MapConfig.State->RoundEndTime && lastRoundCompleted != MapConfig.State->RoundNumber)
+		{
+			lastRoundCompleted = MapConfig.State->RoundNumber;
+			gambitsOnRoundComplete(lastRoundCompleted);
+		}
 #endif
-      
-    // enable prestige if round % 25
+
+		// enable prestige if round % 25
 #if SHOW_PRESTIGE_EVERY_25
-    Moby* prestigeMachineMoby = MapConfig.State->PrestigeMachine;
-    if (prestigeMachineMoby) {
-      int enabled = MapConfig.State->RoundEndTime && ((MapConfig.State->RoundNumber + 0) % 25) == 0;
-        
-      if (enabled) {
-        if (prestigeMachineMoby->CollActive < 0) {
-          pushSnack(0, "Prestige Machine Activated", 120);
-        }
-        prestigeMachineMoby->DrawDist = 64;
-        prestigeMachineMoby->CollActive = 0;
-        prestigeMachineMoby->ModeBits &= ~MOBY_MODE_BIT_DISABLED;
-      } else {
-        prestigeMachineMoby->DrawDist = 0;
-        prestigeMachineMoby->CollActive = -1;
-        prestigeMachineMoby->ModeBits |= MOBY_MODE_BIT_DISABLED;
-      }
-    }
+		Moby *prestigeMachineMoby = MapConfig.State->PrestigeMachine;
+		if (prestigeMachineMoby)
+		{
+			int enabled = MapConfig.State->RoundEndTime && ((MapConfig.State->RoundNumber + 0) % 25) == 0;
+
+			if (enabled)
+			{
+				if (prestigeMachineMoby->CollActive < 0)
+				{
+					pushSnack(0, "Prestige Machine Activated", 120);
+				}
+				prestigeMachineMoby->DrawDist = 64;
+				prestigeMachineMoby->CollActive = 0;
+				prestigeMachineMoby->ModeBits &= ~MOBY_MODE_BIT_DISABLED;
+			}
+			else
+			{
+				prestigeMachineMoby->DrawDist = 0;
+				prestigeMachineMoby->CollActive = -1;
+				prestigeMachineMoby->ModeBits |= MOBY_MODE_BIT_DISABLED;
+			}
+		}
 #endif
-  }
+	}
 
 #if DEBUG_START_ROUND
-  survivalDebugStartRound(DEBUG_START_ROUND);
+	survivalDebugStartRound(DEBUG_START_ROUND);
 #endif
 
 #if DEBUG_MANUAL_SPAWNING
-  survivalDebugManualSpawn();
+	survivalDebugManualSpawn();
 #endif
 
 #if DEBUG_INFINITE_HEALTH
-  survivalDebugInfiniteHealth();
+	survivalDebugInfiniteHealth();
 #endif
 
 #if DEBUG_INFINITE_AMMO
-  survivalDebugInfiniteAmmo();
+	survivalDebugInfiniteAmmo();
 #endif
 
 #if DEBUG_MOONJUMP
-  survivalDebugMoonjump();
+	survivalDebugMoonjump();
 #endif
 
 #if DEBUG_PAYDAY
-  survivalDebugPayday();
+	survivalDebugPayday();
 #endif
 
-  dlPostUpdate();
+	dlPostUpdate();
 	return 0;
 }

--- a/codegen/rc4/survival/upgrade.c
+++ b/codegen/rc4/survival/upgrade.c
@@ -15,34 +15,35 @@
 #include "game.h"
 #include "maputils.h"
 
-GuberEvent* upgradeCreateEvent(Moby* moby, u32 eventType);
+GuberEvent *upgradeCreateEvent(Moby *moby, u32 eventType);
 
 char UpgradeTexIds[] = {
-	[UPGRADE_HEALTH] 94,
-	[UPGRADE_SPEED] 52,
-	[UPGRADE_DAMAGE] 9,
-	[UPGRADE_CRIT] 7,
+		[UPGRADE_HEALTH] 94,
+		[UPGRADE_SPEED] 52,
+		[UPGRADE_DAMAGE] 9,
+		[UPGRADE_CRIT] 7,
 };
 
 //--------------------------------------------------------------------------
-void upgradePlayPickupSound(Moby* moby)
+void upgradePlayPickupSound(Moby *moby)
 {
-  mobyPlaySoundByClass(1, 0, moby, MOBY_ID_PICKUP_PAD);
-}	
+	mobyPlaySoundByClass(1, 0, moby, MOBY_ID_PICKUP_PAD);
+}
 
 //--------------------------------------------------------------------------
-void upgradeDestroy(Moby* moby)
+void upgradeDestroy(Moby *moby)
 {
 	// create event
 	upgradeCreateEvent(moby, UPGRADE_EVENT_DESTROY);
 }
 
 //--------------------------------------------------------------------------
-void upgradePickup(Moby* moby, int pickedUpByPlayerId)
+void upgradePickup(Moby *moby, int pickedUpByPlayerId)
 {
 	// create event
-	GuberEvent * guberEvent = upgradeCreateEvent(moby, UPGRADE_EVENT_PICKUP);
-	if (guberEvent) {
+	GuberEvent *guberEvent = upgradeCreateEvent(moby, UPGRADE_EVENT_PICKUP);
+	if (guberEvent)
+	{
 		guberEventWrite(guberEvent, &pickedUpByPlayerId, sizeof(int));
 	}
 }
@@ -50,75 +51,82 @@ void upgradePickup(Moby* moby, int pickedUpByPlayerId)
 //--------------------------------------------------------------------------
 void upgradeSpawnNew(enum UpgradeType type)
 {
-  char freeBakedSpawnPointsIdxs[BAKED_SPAWNPOINT_COUNT];
-  int freeBakedSpawnPointsIdxCount = 0;
-  int i,j;
-  VECTOR delta, spPos;
-  int isFree = 0;
+	char freeBakedSpawnPointsIdxs[BAKED_SPAWNPOINT_COUNT];
+	int freeBakedSpawnPointsIdxCount = 0;
+	int i, j;
+	VECTOR delta, spPos;
+	int isFree = 0;
 
-  if (!MapConfig.State || !MapConfig.BakedConfig) return;
+	if (!MapConfig.State)
+		return;
 
-  // iterate list of baked spawn points
-  for (i = 0; i < BAKED_SPAWNPOINT_COUNT; ++i) {
+	// iterate list of baked spawn points
+	for (i = 0; i < BAKED_SPAWNPOINT_COUNT; ++i)
+	{
 
-    isFree = 1;
-    
-    // find upgrade spawn points
-    if (MapConfig.BakedConfig->BakedSpawnPoints[i].Type == BAKED_SPAWNPOINT_UPGRADE) {
+		isFree = 1;
 
-      // check if already in use
-      for (j = 0; j < UPGRADE_COUNT; ++j) {
-        if (MapConfig.State->UpgradeMobies[j]) {
-          memcpy(spPos, MapConfig.BakedConfig->BakedSpawnPoints[i].Position, 12);
-          vector_subtract(delta, MapConfig.State->UpgradeMobies[j]->Position, spPos);
-          if (vector_sqrmag(delta) < 0.1) {
-            isFree = 0;
-            break;
-          }
-        }
-      }
+		// find upgrade spawn points
+		if (bakedConfig.BakedSpawnPoints[i].Type == BAKED_SPAWNPOINT_UPGRADE)
+		{
 
-      // 
-      if (isFree) {
-        freeBakedSpawnPointsIdxs[freeBakedSpawnPointsIdxCount++] = i;
-      }
-    }
-  }
+			// check if already in use
+			for (j = 0; j < UPGRADE_COUNT; ++j)
+			{
+				if (MapConfig.State->UpgradeMobies[j])
+				{
+					memcpy(spPos, bakedConfig.BakedSpawnPoints[i].Position, 12);
+					vector_subtract(delta, MapConfig.State->UpgradeMobies[j]->Position, spPos);
+					if (vector_sqrmag(delta) < 0.1)
+					{
+						isFree = 0;
+						break;
+					}
+				}
+			}
 
-  // if no free points then fail
-  if (!freeBakedSpawnPointsIdxCount)
-    return;
+			//
+			if (isFree)
+			{
+				freeBakedSpawnPointsIdxs[freeBakedSpawnPointsIdxCount++] = i;
+			}
+		}
+	}
 
-  // pick random
-  i = freeBakedSpawnPointsIdxs[randRangeInt(0, 100) % freeBakedSpawnPointsIdxCount];
+	// if no free points then fail
+	if (!freeBakedSpawnPointsIdxCount)
+		return;
 
-  // spawn
-  upgradeCreate(MapConfig.BakedConfig->BakedSpawnPoints[i].Position, MapConfig.BakedConfig->BakedSpawnPoints[i].Rotation, type);
+	// pick random
+	i = freeBakedSpawnPointsIdxs[randRangeInt(0, 100) % freeBakedSpawnPointsIdxCount];
+
+	// spawn
+	upgradeCreate(bakedConfig.BakedSpawnPoints[i].Position, bakedConfig.BakedSpawnPoints[i].Rotation, type);
 }
 
 //--------------------------------------------------------------------------
-void upgradePostDraw(Moby* moby)
+void upgradePostDraw(Moby *moby)
 {
 	struct QuadDef quad;
 	MATRIX m2;
-	VECTOR pTL = {0.5,0,0.5,1};
-	VECTOR pTR = {-0.5,0,0.5,1};
-	VECTOR pBL = {0.5,0,-0.5,1};
-	VECTOR pBR = {-0.5,0,-0.5,1};
-	struct UpgradePVar* pvars = (struct UpgradePVar*)moby->PVar;
+	VECTOR pTL = {0.5, 0, 0.5, 1};
+	VECTOR pTR = {-0.5, 0, 0.5, 1};
+	VECTOR pBL = {0.5, 0, -0.5, 1};
+	VECTOR pBR = {-0.5, 0, -0.5, 1};
+	struct UpgradePVar *pvars = (struct UpgradePVar *)moby->PVar;
 	if (!pvars)
 		return;
 
 	// determine color
 	u32 color = 0x00FFFFFF;
-  	float opacity = lerpf(0, 1, clamp(pvars->Uses / 5.0, 0, 1));
-  	color |= (u8)(0x70 * opacity) << 24;
+	float opacity = lerpf(0, 1, clamp(pvars->Uses / 5.0, 0, 1));
+	color |= (u8)(0x70 * opacity) << 24;
 
 	// set draw args
 	matrix_unit(m2);
 
 	// init
- 	gfxResetQuad(&quad);
+	gfxResetQuad(&quad);
 
 	// color of each corner?
 	vector_copy(quad.VertexPositions[0], pTL);
@@ -126,72 +134,76 @@ void upgradePostDraw(Moby* moby)
 	vector_copy(quad.VertexPositions[2], pBL);
 	vector_copy(quad.VertexPositions[3], pBR);
 	quad.VertexColors[0] = quad.VertexColors[1] = quad.VertexColors[2] = quad.VertexColors[3] = color;
-	quad.VertexUVs[0] = (struct UV){0,0};
-	quad.VertexUVs[1] = (struct UV){1,0};
-	quad.VertexUVs[2] = (struct UV){0,1};
-	quad.VertexUVs[3] = (struct UV){1,1};
+	quad.VertexUVs[0] = (struct UV){0, 0};
+	quad.VertexUVs[1] = (struct UV){1, 0};
+	quad.VertexUVs[2] = (struct UV){0, 1};
+	quad.VertexUVs[3] = (struct UV){1, 1};
 	quad.Clamp = 0x0000000100000001;
 	quad.Tex0 = gfxGetFrameTex(UpgradeTexIds[pvars->Type]);
 	quad.Tex1 = 0xFF9000000260;
 	quad.Alpha = 0x8000000044;
 
 	// copy from moby
-	memcpy(m2, moby->M0_03, sizeof(VECTOR)*3);
+	memcpy(m2, moby->M0_03, sizeof(VECTOR) * 3);
 	memcpy(&m2[12], moby->Position, sizeof(VECTOR));
 
 	// draw
-	gfxDrawQuad((void*)0x00222590, &quad, m2, 1);
+	gfxDrawQuad((void *)0x00222590, &quad, m2, 1);
 }
 
 //--------------------------------------------------------------------------
-void upgradeUpdate(Moby* moby)
+void upgradeUpdate(Moby *moby)
 {
-	const float rotSpeeds[] = { 0.05, 0.02, -0.03, -0.1 };
-	const int opacities[] = { 64, 32, 44, 51 };
+	const float rotSpeeds[] = {0.05, 0.02, -0.03, -0.1};
+	const int opacities[] = {64, 32, 44, 51};
 
 	int i;
-	struct UpgradePVar* pvars = (struct UpgradePVar*)moby->PVar;
+	struct UpgradePVar *pvars = (struct UpgradePVar *)moby->PVar;
 	if (!pvars)
 		return;
 
 	// register draw event
-	gfxRegisterDrawFunction((void**)0x0022251C, (gfxDrawFuncDef*)&upgradePostDraw, moby);
+	gfxRegisterDrawFunction((void **)0x0022251C, (gfxDrawFuncDef *)&upgradePostDraw, moby);
 
-  // draw on radar
-  int blipIdx = radarGetBlipIndex(moby);
-  if (blipIdx >= 0) {
-    RadarBlip * blip = radarGetBlips() + blipIdx;
-    blip->X = moby->Position[0];
-    blip->Y = moby->Position[1];
-    blip->Life = 0x1F;
-    blip->Type = 4;
-    blip->Team = TEAM_AQUA;
-  }
+	// draw on radar
+	int blipIdx = radarGetBlipIndex(moby);
+	if (blipIdx >= 0)
+	{
+		RadarBlip *blip = radarGetBlips() + blipIdx;
+		blip->X = moby->Position[0];
+		blip->Y = moby->Position[1];
+		blip->Life = 0x1F;
+		blip->Type = 4;
+		blip->Team = TEAM_AQUA;
+	}
 
 	return;
 
 	// handle particles
 	u32 color = 0x80C0C0C0;
-	for (i = 0; i < 4; ++i) {
-		struct PartInstance * particle = pvars->Particles[i];
-		if (!particle) {
+	for (i = 0; i < 4; ++i)
+	{
+		struct PartInstance *particle = pvars->Particles[i];
+		if (!particle)
+		{
 			pvars->Particles[i] = particle = spawnParticle(moby->Position, color, opacities[i], i);
 		}
 
 		// update
-		if (particle) {
+		if (particle)
+		{
 			particle->Rot = (int)((gameGetTime() + (i * 100)) / (TIME_SECOND * rotSpeeds[i])) & 0xFF;
 		}
 	}
 }
 
 //--------------------------------------------------------------------------
-GuberEvent* upgradeCreateEvent(Moby* moby, u32 eventType)
+GuberEvent *upgradeCreateEvent(Moby *moby, u32 eventType)
 {
-	GuberEvent * event = NULL;
+	GuberEvent *event = NULL;
 
 	// create guber object
-	Guber* guber = guberGetObjectByMoby(moby);
+	Guber *guber = guberGetObjectByMoby(moby);
 	if (guber)
 		event = guberEventCreateEvent(guber, eventType, 0, 0);
 
@@ -199,9 +211,9 @@ GuberEvent* upgradeCreateEvent(Moby* moby, u32 eventType)
 }
 
 //--------------------------------------------------------------------------
-int upgradeHandleEvent_Spawn(Moby* moby, GuberEvent* event)
+int upgradeHandleEvent_Spawn(Moby *moby, GuberEvent *event)
 {
-	VECTOR p,r;
+	VECTOR p, r;
 	struct UpgradeSpawnEventArgs args;
 
 	// read event
@@ -216,69 +228,71 @@ int upgradeHandleEvent_Spawn(Moby* moby, GuberEvent* event)
 	// set update
 	moby->PUpdate = &upgradeUpdate;
 
-	// 
-	//moby->ModeBits |= 0x30;
-	//moby->GlowRGBA = MobSecondaryColors[(int)args.MobType];
-	//moby->PrimaryColor = MobPrimaryColors[(int)args.MobType];
+	//
+	// moby->ModeBits |= 0x30;
+	// moby->GlowRGBA = MobSecondaryColors[(int)args.MobType];
+	// moby->PrimaryColor = MobPrimaryColors[(int)args.MobType];
 	moby->CollData = NULL;
 	moby->DrawDist = 0;
-  	moby->ModeBits = 0;
- 	moby->AnimSeq = NULL;
-  	moby->AnimSeqId = moby->LSeq = 0;
-	//moby->PClass = NULL;
+	moby->ModeBits = 0;
+	moby->AnimSeq = NULL;
+	moby->AnimSeqId = moby->LSeq = 0;
+	// moby->PClass = NULL;
 
 	// update pvars
-	struct UpgradePVar* pvars = (struct UpgradePVar*)moby->PVar;
+	struct UpgradePVar *pvars = (struct UpgradePVar *)moby->PVar;
 	pvars->Type = args.Type;
- 	pvars->Uses = UPGRADE_MAX_USES;
-  	pvars->TexId = UpgradeTexIds[args.Type];
+	pvars->Uses = UPGRADE_MAX_USES;
+	pvars->TexId = UpgradeTexIds[args.Type];
 	memset(pvars->Particles, 0, sizeof(pvars->Particles));
 
 	// set team
-	Guber* guber = guberGetObjectByMoby(moby);
+	Guber *guber = guberGetObjectByMoby(moby);
 	if (guber)
-		((GuberMoby*)guber)->TeamNum = 10;
-	
+		((GuberMoby *)guber)->TeamNum = 10;
+
 	// set reference in state
-  	if (MapConfig.State)
+	if (MapConfig.State)
 		MapConfig.State->UpgradeMobies[args.Type] = moby;
 
-	// 
+	//
 	mobySetState(moby, 0, -1);
 	DPRINTF("upgrade spawned at %08X type:%d\n", (u32)moby, pvars->Type);
 	return 0;
 }
 
 //--------------------------------------------------------------------------
-int upgradeHandleEvent_Destroy(Moby* moby, GuberEvent* event)
+int upgradeHandleEvent_Destroy(Moby *moby, GuberEvent *event)
 {
 	int i;
-	struct UpgradePVar* pvars = (struct UpgradePVar*)moby->PVar;
+	struct UpgradePVar *pvars = (struct UpgradePVar *)moby->PVar;
 	if (!pvars)
 		return 0;
 
 	// destroy particles
-	for (i = 0; i < 4; ++i) {
-		if (pvars->Particles[i]) {
+	for (i = 0; i < 4; ++i)
+	{
+		if (pvars->Particles[i])
+		{
 			destroyParticle(pvars->Particles[i]);
 			pvars->Particles[i] = 0;
 		}
 	}
 
-  // remove reference
-  if (MapConfig.State && MapConfig.State->UpgradeMobies[pvars->Type] == moby)
-    MapConfig.State->UpgradeMobies[pvars->Type] = NULL;
+	// remove reference
+	if (MapConfig.State && MapConfig.State->UpgradeMobies[pvars->Type] == moby)
+		MapConfig.State->UpgradeMobies[pvars->Type] = NULL;
 
 	guberMobyDestroy(moby);
 	return 0;
 }
 
 //--------------------------------------------------------------------------
-int upgradeHandleEvent_Pickup(Moby* moby, GuberEvent* event)
+int upgradeHandleEvent_Pickup(Moby *moby, GuberEvent *event)
 {
 	struct UpgradePickupEventArgs args;
-	Player** players = playerGetAll();
-	struct UpgradePVar* pvars = (struct UpgradePVar*)moby->PVar;
+	Player **players = playerGetAll();
+	struct UpgradePVar *pvars = (struct UpgradePVar *)moby->PVar;
 
 	if (!pvars)
 		return 0;
@@ -286,87 +300,95 @@ int upgradeHandleEvent_Pickup(Moby* moby, GuberEvent* event)
 	// read event
 	guberEventRead(event, &args, sizeof(struct UpgradePickupEventArgs));
 
-	Player* targetPlayer = players[args.PickedUpByPlayerId];
+	Player *targetPlayer = players[args.PickedUpByPlayerId];
 	if (!targetPlayer)
 		return 0;
 
 	// give
-  if (MapConfig.State) {
-	  MapConfig.State->PlayerStates[args.PickedUpByPlayerId].State.Upgrades[pvars->Type] += 1;
-  }
+	if (MapConfig.State)
+	{
+		MapConfig.State->PlayerStates[args.PickedUpByPlayerId].State.Upgrades[pvars->Type] += 1;
+	}
 
 	// handle effect
-	if (targetPlayer->IsLocal) {
+	if (targetPlayer->IsLocal)
+	{
 		switch (pvars->Type)
 		{
-			case UPGRADE_HEALTH:
-			{
-				uiShowPopup(targetPlayer->LocalPlayerIndex, "Health Upgraded!");
-				break;
-			}
-			case UPGRADE_SPEED:
-			{
-				uiShowPopup(targetPlayer->LocalPlayerIndex, "Speed Upgraded!");
-				break;
-			}
-			case UPGRADE_DAMAGE:
-			{
-				uiShowPopup(targetPlayer->LocalPlayerIndex, "Damage Upgraded!");
-				break;
-			}
-			case UPGRADE_CRIT:
-			{
-				uiShowPopup(targetPlayer->LocalPlayerIndex, "Critical Hit Upgraded!");
-				break;
-			}
+		case UPGRADE_HEALTH:
+		{
+			uiShowPopup(targetPlayer->LocalPlayerIndex, "Health Upgraded!");
+			break;
+		}
+		case UPGRADE_SPEED:
+		{
+			uiShowPopup(targetPlayer->LocalPlayerIndex, "Speed Upgraded!");
+			break;
+		}
+		case UPGRADE_DAMAGE:
+		{
+			uiShowPopup(targetPlayer->LocalPlayerIndex, "Damage Upgraded!");
+			break;
+		}
+		case UPGRADE_CRIT:
+		{
+			uiShowPopup(targetPlayer->LocalPlayerIndex, "Critical Hit Upgraded!");
+			break;
+		}
 		}
 	}
-	
+
 	// play pickup sound
 	upgradePlayPickupSound(moby);
 
-  // reduce uses, if not post round 25 break
-  // respawn at next spot if used
+	// reduce uses, if not post round 25 break
+	// respawn at next spot if used
 #if !DEBUG
-  if (!MapConfig.State || MapConfig.State->RoundEndTime != -1) {
-    pvars->Uses--;
-  }
+	if (!MapConfig.State || MapConfig.State->RoundEndTime != -1)
+	{
+		pvars->Uses--;
+	}
 #endif
-  if (!pvars->Uses && gameAmIHost()) {
-    upgradeSpawnNew(pvars->Type);
-    upgradeDestroy(moby);
-  }
-  
+	if (!pvars->Uses && gameAmIHost())
+	{
+		upgradeSpawnNew(pvars->Type);
+		upgradeDestroy(moby);
+	}
+
 	return 0;
 }
 
 //--------------------------------------------------------------------------
-struct GuberMoby* upgradeGetGuber(Moby* moby)
+struct GuberMoby *upgradeGetGuber(Moby *moby)
 {
 	if (moby->OClass == UPGRADE_MOBY_OCLASS && moby->PVar)
 		return moby->GuberMoby;
-	
+
 	return 0;
 }
 
 //--------------------------------------------------------------------------
-int upgradeHandleEvent(Moby* moby, GuberEvent* event)
+int upgradeHandleEvent(Moby *moby, GuberEvent *event)
 {
-	struct UpgradePVar* pvars = (struct UpgradePVar*)moby->PVar;
+	struct UpgradePVar *pvars = (struct UpgradePVar *)moby->PVar;
 
-	if (isInGame() && !mobyIsDestroyed(moby) && moby->OClass == UPGRADE_MOBY_OCLASS && pvars) {
+	if (isInGame() && !mobyIsDestroyed(moby) && moby->OClass == UPGRADE_MOBY_OCLASS && pvars)
+	{
 		u32 upgradeEvent = event->NetEvent.EventID;
 
 		switch (upgradeEvent)
 		{
-			case UPGRADE_EVENT_SPAWN: return upgradeHandleEvent_Spawn(moby, event);
-			case UPGRADE_EVENT_DESTROY: return upgradeHandleEvent_Destroy(moby, event);
-			case UPGRADE_EVENT_PICKUP: return upgradeHandleEvent_Pickup(moby, event);
-			default:
-			{
-				DPRINTF("unhandle upgrade event %d\n", upgradeEvent);
-				break;
-			}
+		case UPGRADE_EVENT_SPAWN:
+			return upgradeHandleEvent_Spawn(moby, event);
+		case UPGRADE_EVENT_DESTROY:
+			return upgradeHandleEvent_Destroy(moby, event);
+		case UPGRADE_EVENT_PICKUP:
+			return upgradeHandleEvent_Pickup(moby, event);
+		default:
+		{
+			DPRINTF("unhandle upgrade event %d\n", upgradeEvent);
+			break;
+		}
 		}
 	}
 
@@ -379,12 +401,12 @@ int upgradeCreate(VECTOR position, VECTOR rotation, enum UpgradeType upgradeType
 	struct UpgradeSpawnEventArgs args;
 
 	// create guber object
-	GuberEvent * guberEvent = 0;
+	GuberEvent *guberEvent = 0;
 	guberMobyCreateSpawned(UPGRADE_MOBY_OCLASS, sizeof(struct UpgradePVar), &guberEvent, NULL);
 	if (guberEvent)
 	{
 		args.Type = upgradeType;
-		
+
 		guberEventWrite(guberEvent, position, 12);
 		guberEventWrite(guberEvent, rotation, 12);
 		guberEventWrite(guberEvent, &args, sizeof(struct UpgradeSpawnEventArgs));
@@ -393,32 +415,31 @@ int upgradeCreate(VECTOR position, VECTOR rotation, enum UpgradeType upgradeType
 	{
 		DPRINTF("failed to guberevent upgrade\n");
 	}
-  
-  return guberEvent != NULL;
+
+	return guberEvent != NULL;
 }
 
 //--------------------------------------------------------------------------
 void upgradeInit(void)
 {
-  Moby* temp = mobySpawn(UPGRADE_MOBY_OCLASS, 0);
-  if (!temp)
-    return;
+	Moby *temp = mobySpawn(UPGRADE_MOBY_OCLASS, 0);
+	if (!temp)
+		return;
 
-  // set vtable callbacks
-  u32 mobyFunctionsPtr = (u32)mobyGetFunctions(temp);
-  if (mobyFunctionsPtr) {
-    mapInstallMobyFunctions(mobyFunctionsPtr);
-    DPRINTF("UPGRADE oClass:%04X mClass:%02X func:%08X getGuber:%08X handleEvent:%08X\n", temp->OClass, temp->MClass, mobyFunctionsPtr, *(u32*)(mobyFunctionsPtr + 0x04), *(u32*)(mobyFunctionsPtr + 0x14));
-  }
-  mobyDestroy(temp);
+	// set vtable callbacks
+	u32 mobyFunctionsPtr = (u32)mobyGetFunctions(temp);
+	if (mobyFunctionsPtr)
+	{
+		mapInstallMobyFunctions(mobyFunctionsPtr);
+		DPRINTF("UPGRADE oClass:%04X mClass:%02X func:%08X getGuber:%08X handleEvent:%08X\n", temp->OClass, temp->MClass, mobyFunctionsPtr, *(u32 *)(mobyFunctionsPtr + 0x04), *(u32 *)(mobyFunctionsPtr + 0x14));
+	}
+	mobyDestroy(temp);
 
-  MapConfig.CreateUpgradePickupFunc = &upgradeCreate;
-  MapConfig.OnUpgradePickupEventFunc = &upgradeHandleEvent;
-  MapConfig.PickupUpgradeFunc = &upgradePickup;
+	MapConfig.Functions.CreateUpgradePickupFunc = &upgradeCreate;
+	MapConfig.Functions.PickupUpgradeFunc = &upgradePickup;
 }
 
 //--------------------------------------------------------------------------
 void upgradeTick(void)
 {
-
 }

--- a/codegen/rc4/survival/utils.c
+++ b/codegen/rc4/survival/utils.c
@@ -1,8 +1,8 @@
 /***************************************************
  * FILENAME :		maputils.c
- * 
+ *
  * DESCRIPTION :
- * 		
+ *
  * AUTHOR :			Daniel "Dnawrkshp" Gerendasy
  */
 
@@ -36,267 +36,322 @@
 extern char LocalPlayerStrBuffer[2][64];
 extern struct SurvivalMapConfig MapConfig;
 
-/* 
+/*
  * paid sound def
  */
 SoundDef PaidSoundDef =
-{
-	0.0,	// MinRange
-	20.0,	// MaxRange
-	100,		// MinVolume
-	2000,		// MaxVolume
-	0,			// MinPitch
-	0,			// MaxPitch
-	0,			// Loop
-	0x10,		// Flags
-	32,		  // Index
-	3			  // Bank
+		{
+				0.0,	// MinRange
+				20.0, // MaxRange
+				100,	// MinVolume
+				2000, // MaxVolume
+				0,		// MinPitch
+				0,		// MaxPitch
+				0,		// Loop
+				0x10, // Flags
+				32,		// Index
+				3			// Bank
 };
 
-
 //--------------------------------------------------------------------------
-void playPaidSound(Player* player)
+void playPaidSound(Player *player)
 {
-  if (!player) return;
-  soundPlay(&PaidSoundDef, 0, player->PlayerMoby, 0, 0x400);
+	if (!player)
+		return;
+	soundPlay(&PaidSoundDef, 0, player->PlayerMoby, 0, 0x400);
 }
 
 //--------------------------------------------------------------------------
-int tryPlayerInteract(Moby* moby, Player* player, char* message, char* lowerMessage, int boltCost, int tokenCost, int actionCooldown, float sqrDistance, int btns)
+int tryPlayerInteract(Moby *moby, Player *player, char *message, char *lowerMessage, int boltCost, int tokenCost, int actionCooldown, float sqrDistance, int btns)
 {
-  static int shown[GAME_MAX_LOCALS] = {0,0};
-  VECTOR delta;
-  if (!player || !player->PlayerMoby || !player->IsLocal || !isInGame())
-    return 0;
+	static int shown[GAME_MAX_LOCALS] = {0, 0};
+	VECTOR delta;
+	if (!player || !player->PlayerMoby || !player->IsLocal || !isInGame())
+		return 0;
 
-  struct SurvivalPlayer* playerData = NULL;
-  int localPlayerIndex = player->LocalPlayerIndex;
-  int pIndex = player->PlayerId;
+	struct SurvivalPlayer *playerData = NULL;
+	int localPlayerIndex = player->LocalPlayerIndex;
+	int pIndex = player->PlayerId;
 
-  if (MapConfig.State) {
-    playerData = &MapConfig.State->PlayerStates[pIndex];
-  }
-  
-  vector_subtract(delta, player->PlayerPosition, moby->Position);
-  if (vector_sqrmag(delta) < sqrDistance) {
+	if (MapConfig.State)
+	{
+		playerData = &MapConfig.State->PlayerStates[pIndex];
+	}
 
-    // draw help popup
-    snprintf(LocalPlayerStrBuffer[localPlayerIndex], sizeof(LocalPlayerStrBuffer[localPlayerIndex]), message);
-    uiShowPopup(player->LocalPlayerIndex, LocalPlayerStrBuffer[localPlayerIndex]);
-    shown[localPlayerIndex] = gameGetTime();
+	vector_subtract(delta, player->PlayerPosition, moby->Position);
+	if (vector_sqrmag(delta) < sqrDistance)
+	{
 
-    // handle pad input
-    if (padGetAnyButtonDown(localPlayerIndex, btns) > 0 && (!playerData || (playerData->State.Bolts >= boltCost && playerData->State.CurrentTokens >= tokenCost))) {
-      if (playerData) {
-        //playerData->State.Bolts -= boltCost;
-        //playerData->State.CurrentTokens -= tokenCost;
-        playerData->ActionCooldownTicks = actionCooldown;
-        playerData->MessageCooldownTicks = 5;
-      }
+		// draw help popup
+		snprintf(LocalPlayerStrBuffer[localPlayerIndex], sizeof(LocalPlayerStrBuffer[localPlayerIndex]), message);
+		uiShowPopup(player->LocalPlayerIndex, LocalPlayerStrBuffer[localPlayerIndex]);
+		shown[localPlayerIndex] = gameGetTime();
 
-      return 1;
-    }
-    
-    // draw lower message
-    if (lowerMessage) {
-      char* a = uiMsgString(0x2415);
-      strncpy(a, lowerMessage, 0x40);
-      uiShowLowerPopup(0, 0x2415);
-    }
-  } else if (shown[localPlayerIndex] && gameGetTime() > shown[localPlayerIndex]) {
-    hudHidePopup();
-    shown[localPlayerIndex] = 0;
-  }
+		// handle pad input
+		if (padGetAnyButtonDown(localPlayerIndex, btns) > 0 && (!playerData || (playerData->State.Bolts >= boltCost && playerData->State.CurrentTokens >= tokenCost)))
+		{
+			if (playerData)
+			{
+				// playerData->State.Bolts -= boltCost;
+				// playerData->State.CurrentTokens -= tokenCost;
+				playerData->ActionCooldownTicks = actionCooldown;
+				playerData->MessageCooldownTicks = 5;
+			}
 
-  return 0;
+			return 1;
+		}
+
+		// draw lower message
+		if (lowerMessage)
+		{
+			char *a = uiMsgString(0x2415);
+			strncpy(a, lowerMessage, 0x40);
+			uiShowLowerPopup(0, 0x2415);
+		}
+	}
+	else if (shown[localPlayerIndex] && gameGetTime() > shown[localPlayerIndex])
+	{
+		hudHidePopup();
+		shown[localPlayerIndex] = 0;
+	}
+
+	return 0;
 }
 
 //--------------------------------------------------------------------------
-int mobyIsMob(Moby* moby)
+int mobyIsMob(Moby *moby)
 {
-  if (!moby) return 0;
+	if (!moby)
+		return 0;
 
-  int i;
-  for (i = 0; i < MapConfig.DefaultSpawnParamsCount; ++i) {
-    if (MapConfig.DefaultSpawnParams[i].OClass == moby->OClass)
-      return 1;
-  }
+	int i;
+	for (i = 0; i < MapConfig.DefaultSpawnParamsCount; ++i)
+	{
+		if (MapConfig.DefaultSpawnParams[i].OClass == moby->OClass)
+			return 1;
+	}
 
-  return 0;
+	return 0;
 }
 
 //--------------------------------------------------------------------------
 int playerHasBlessing(int playerId, int blessing)
 {
-  if (!MapConfig.State) return 0;
+	if (!MapConfig.State)
+		return 0;
 
-  int i;
-  for (i = 0; i < PLAYER_MAX_BLESSINGS; ++i) {
-    if (MapConfig.State->PlayerStates[playerId].State.ItemBlessings[i] == blessing) return 1;
-  }
+	int i;
+	for (i = 0; i < PLAYER_MAX_BLESSINGS; ++i)
+	{
+		if (MapConfig.State->PlayerStates[playerId].State.ItemBlessings[i] == blessing)
+			return 1;
+	}
 
-  return 0;
+	return 0;
 }
 
 //--------------------------------------------------------------------------
 int playerGetStackableCount(int playerId, int stackable)
 {
-  if (!MapConfig.State) return 0;
+	if (!MapConfig.State)
+		return 0;
 
-  return MapConfig.State->PlayerStates[playerId].State.ItemStackable[stackable];
+	return MapConfig.State->PlayerStates[playerId].State.ItemStackable[stackable];
 }
 
 //--------------------------------------------------------------------------
-int bakedSpawnGetFirst(int bakedSpawnType, VECTOR outPos, VECTOR outRot) {
-  if (!MapConfig.BakedConfig) return 0;
+void playerTeleportToSpawn(Player *player, float dealtDamagePercentOfMaxHealth)
+{
+	VECTOR p, r, o;
+	float damage = player->MaxHealth * dealtDamagePercentOfMaxHealth;
 
-  int i;
-  for (i = 0; i < BAKED_SPAWNPOINT_COUNT; ++i) {
-    if (MapConfig.BakedConfig->BakedSpawnPoints[i].Type == bakedSpawnType) {
+	// get spawn point
+	if (!MapConfig.Functions.OnPlayerGetResFunc || !MapConfig.Functions.OnPlayerGetResFunc(player, p, r, 0))
+		playerGetSpawnpoint(player, p, r, 0);
 
-      memcpy(outPos, MapConfig.BakedConfig->BakedSpawnPoints[i].Position, 12);
-      memcpy(outRot, MapConfig.BakedConfig->BakedSpawnPoints[i].Rotation, 12);
-      return 1;
-    }
-  }
+	// spawn around point, to avoid risk of multiple players spawning on top of one another
+	vector_fromyaw(o, (player->PlayerId / (float)GAME_MAX_PLAYERS) * MATH_TAU - MATH_PI);
+	vector_scale(o, o, 2.5);
+	vector_add(p, p, o);
 
-  return 0;
+	// teleport, damage, and set inv timer
+	playerSetPosRot(player, p, r);
+	playerSetHealth(player, maxf(0, player->Health - damage));
+	player->timers.invincibilityTimer = PLAYER_RESPAWN_INV_TICKS;
+}
+
+//--------------------------------------------------------------------------
+int bakedSpawnGetFirst(int bakedSpawnType, VECTOR outPos, VECTOR outRot)
+{
+	int i;
+	for (i = 0; i < BAKED_SPAWNPOINT_COUNT; ++i)
+	{
+		if (bakedConfig.BakedSpawnPoints[i].Type == bakedSpawnType)
+		{
+
+			memcpy(outPos, bakedConfig.BakedSpawnPoints[i].Position, 12);
+			memcpy(outRot, bakedConfig.BakedSpawnPoints[i].Rotation, 12);
+			return 1;
+		}
+	}
+
+	return 0;
 }
 
 //--------------------------------------------------------------------------
 int localPlayerHasInput(void)
 {
-  Player* localPlayer = playerGetFromSlot(0);
-  if (!localPlayer) return 0;
+	Player *localPlayer = playerGetFromSlot(0);
+	if (!localPlayer)
+		return 0;
 
-  return !localPlayer->timers.noInput && !gameIsStartMenuOpen(0) && (!MapConfig.State || !MapConfig.State->PlayerStates[localPlayer->PlayerId].IsInWeaponsMenu);
+	return !localPlayer->timers.noInput && !gameIsStartMenuOpen(0) && (!MapConfig.State || !MapConfig.State->PlayerStates[localPlayer->PlayerId].IsInWeaponsMenu);
 }
 
 //--------------------------------------------------------------------------
-Moby* mapOnGuberEventCreateMoby(int oclass, int pvarSize)
+Moby *mapOnGuberEventCreateMoby(int oclass, int pvarSize)
 {
-  if (mobyGetNumSpawnableMobys() < 50) {
-    Moby* m = mobyFindNextByOClass(mobyListGetStart(), 0x13A1);
-    if (!m) return NULL;
-    if (m) {
-      mobyDestroy(m);
-      m->CollCnt = 0; // lets the moby be reused instantly
-    }
-  }
+	if (mobyGetNumSpawnableMobys() < 50)
+	{
+		Moby *m = mobyFindNextByOClass(mobyListGetStart(), 0x13A1);
+		if (!m)
+			return NULL;
+		if (m)
+		{
+			mobyDestroy(m);
+			m->CollCnt = 0; // lets the moby be reused instantly
+		}
+	}
 
-  return mobySpawn(oclass, pvarSize);
+	return mobySpawn(oclass, pvarSize);
 }
 
 //--------------------------------------------------------------------------
 void mapApplyFixes(void)
 {
-  //HOOK_JAL(0x0061c3ec, &mapOnGuberEventCreateMoby);
+	// HOOK_JAL(0x0061c3ec, &mapOnGuberEventCreateMoby);
 }
 
 //--------------------------------------------------------------------------
 void mapPrintGambit(int gambit)
 {
-  char gambitName[32];
-  if (!gambit) return;
-  
-  // read ex data
-  char exDataBuf[1024];
-  if (PATCH_INTEROP->ReadCustomMapExtraData(PATCH_INTEROP->MapLoaderFilename, exDataBuf, sizeof(exDataBuf), CUSTOM_MODE_SURVIVAL) > 8) {
-    int gambitCount = *(int*)(exDataBuf + 4);
-    char* gambits = (char*)(exDataBuf + 8);
+	char gambitName[32];
+	if (!gambit)
+		return;
 
-    int i;
-    for (i = 0; i < gambitCount; ++i) {
-      if ((i+1) == gambit) {
-        strncpy(gambitName, gambits, sizeof(gambitName));
-        break;
-      }
+	// read ex data
+	char exDataBuf[1024];
+	if (PATCH_INTEROP->ReadCustomMapExtraData(PATCH_INTEROP->MapLoaderFilename, exDataBuf, sizeof(exDataBuf), CUSTOM_MODE_SURVIVAL) > 8)
+	{
+		int gambitCount = *(int *)(exDataBuf + 4);
+		char *gambits = (char *)(exDataBuf + 8);
 
-      gambits += strlen(gambits) + 1;
-      gambits += strlen(gambits) + 1;
-    }
-  }
+		int i;
+		for (i = 0; i < gambitCount; ++i)
+		{
+			if ((i + 1) == gambit)
+			{
+				strncpy(gambitName, gambits, sizeof(gambitName));
+				break;
+			}
 
-  // show user
-  snprintf(exDataBuf, sizeof(exDataBuf), "Gambit \x0E%s\x08 Active", gambitName);
-  pushSnack(0, exDataBuf, TPS * 10);
-  pushSnack(1, exDataBuf, TPS * 10);
+			gambits += strlen(gambits) + 1;
+			gambits += strlen(gambits) + 1;
+		}
+	}
+
+	// show user
+	snprintf(exDataBuf, sizeof(exDataBuf), "Gambit \x0E%s\x08 Active", gambitName);
+	pushSnack(0, exDataBuf, TPS * 10);
+	pushSnack(1, exDataBuf, TPS * 10);
 }
 
 //--------------------------------------------------------------------------
 void mapSendSendGambitCompletedMessage(int gambit)
 {
-  if (!gambit) return;
-  
-  void* lobbyConnection = netGetLobbyServerConnection();
-  if (!lobbyConnection) return;
+	if (!gambit)
+		return;
 
-  UpdateSurvivalGambitCompletedRequest_t msg = {
-    .GambitIdx = gambit
-  };
+	void *lobbyConnection = netGetLobbyServerConnection();
+	if (!lobbyConnection)
+		return;
 
-  // read ex data
-  char exDataBuf[1024];
-  if (PATCH_INTEROP->ReadCustomMapExtraData(PATCH_INTEROP->MapLoaderFilename, exDataBuf, sizeof(exDataBuf), CUSTOM_MODE_SURVIVAL) > 8) {
-    int gambitCount = *(int*)(exDataBuf + 4);
-    char* gambits = (char*)(exDataBuf + 8);
+	UpdateSurvivalGambitCompletedRequest_t msg = {
+			.GambitIdx = gambit};
 
-    int i;
-    for (i = 0; i < gambitCount; ++i) {
-      if ((i+1) == gambit) {
-        strncpy(msg.GambitName, gambits, sizeof(msg.GambitName));
-        break;
-      }
+	// read ex data
+	char exDataBuf[1024];
+	if (PATCH_INTEROP->ReadCustomMapExtraData(PATCH_INTEROP->MapLoaderFilename, exDataBuf, sizeof(exDataBuf), CUSTOM_MODE_SURVIVAL) > 8)
+	{
+		int gambitCount = *(int *)(exDataBuf + 4);
+		char *gambits = (char *)(exDataBuf + 8);
 
-      gambits += strlen(gambits) + 1;
-      gambits += strlen(gambits) + 1;
-    }
-  }
+		int i;
+		for (i = 0; i < gambitCount; ++i)
+		{
+			if ((i + 1) == gambit)
+			{
+				strncpy(msg.GambitName, gambits, sizeof(msg.GambitName));
+				break;
+			}
 
-  // send request to server
-  strncpy(msg.MapFilename, PATCH_INTEROP->MapLoaderFilename, sizeof(msg.MapFilename));
-  netSendCustomAppMessage(NET_DELIVERY_CRITICAL, lobbyConnection, NET_LOBBY_CLIENT_INDEX, CUSTOM_MSG_ID_CLIENT_UPDATE_SURVIVAL_GAMBIT_COMPLETED_REQUEST, sizeof(msg), &msg);
+			gambits += strlen(gambits) + 1;
+			gambits += strlen(gambits) + 1;
+		}
+	}
 
-  // show user
-  snprintf(exDataBuf, sizeof(exDataBuf), "Completed Gambit %s!", msg.GambitName);
-  pushSnack(0, exDataBuf, TPS * 10);
-  pushSnack(1, exDataBuf, TPS * 10);
+	// send request to server
+	strncpy(msg.MapFilename, PATCH_INTEROP->MapLoaderFilename, sizeof(msg.MapFilename));
+	netSendCustomAppMessage(NET_DELIVERY_CRITICAL, lobbyConnection, NET_LOBBY_CLIENT_INDEX, CUSTOM_MSG_ID_CLIENT_UPDATE_SURVIVAL_GAMBIT_COMPLETED_REQUEST, sizeof(msg), &msg);
+
+	// show user
+	snprintf(exDataBuf, sizeof(exDataBuf), "Completed Gambit %s!", msg.GambitName);
+	pushSnack(0, exDataBuf, TPS * 10);
+	pushSnack(1, exDataBuf, TPS * 10);
 }
 
 //--------------------------------------------------------------------------
 void mapLocalPlayerEnforceSingleWeaponRestriction(int localPlayerIdx, int weaponId, int hard)
 {
-  Player* player = playerGetFromSlot(localPlayerIdx);
-  if (!playerIsValid(player)) return;
+	Player *player = playerGetFromSlot(localPlayerIdx);
+	if (!playerIsValid(player))
+		return;
 
-  playerSetLocalEquipslot(localPlayerIdx, 0, weaponId);
-  playerSetLocalEquipslot(localPlayerIdx, 1, 0);
-  playerSetLocalEquipslot(localPlayerIdx, 2, 0);
-  
-  int s;
-  for (s = WEAPON_SLOT_VIPERS; s < WEAPON_SLOT_COUNT; ++s) {
-    int gadget = weaponSlotToId(s);
-    if (gadget == weaponId) {
-      if (player->GadgetBox->Gadgets[gadget].Level < 0)
-        playerGiveWeapon(player->GadgetBox, gadget, 0, 1);
-    } else {
-      if (hard) {
-        player->GadgetBox->Gadgets[gadget].Level = -1;
-        player->GadgetBox->Gadgets[gadget].Ammo = 0;
-      }
+	playerSetLocalEquipslot(localPlayerIdx, 0, weaponId);
+	playerSetLocalEquipslot(localPlayerIdx, 1, 0);
+	playerSetLocalEquipslot(localPlayerIdx, 2, 0);
 
-      if (player->WeaponHeldId == gadget) {
-        player->ChangeWeaponHeldId = weaponId;
-      }
-    }
-  }
+	int s;
+	for (s = WEAPON_SLOT_VIPERS; s < WEAPON_SLOT_COUNT; ++s)
+	{
+		int gadget = weaponSlotToId(s);
+		if (gadget == weaponId)
+		{
+			if (player->GadgetBox->Gadgets[gadget].Level < 0)
+				playerGiveWeapon(player->GadgetBox, gadget, 0, 1);
+		}
+		else
+		{
+			if (hard)
+			{
+				player->GadgetBox->Gadgets[gadget].Level = -1;
+				player->GadgetBox->Gadgets[gadget].Ammo = 0;
+			}
+
+			if (player->WeaponHeldId == gadget)
+			{
+				player->ChangeWeaponHeldId = weaponId;
+			}
+		}
+	}
 }
 
 //--------------------------------------------------------------------------
 void mapEnforceSingleWeaponRestriction(int weaponId)
 {
-  int i;
-  for (i = 0; i < GAME_MAX_LOCALS; ++i) {
-    mapLocalPlayerEnforceSingleWeaponRestriction(i, weaponId, 1);
-  }
+	int i;
+	for (i = 0; i < GAME_MAX_LOCALS; ++i)
+	{
+		mapLocalPlayerEnforceSingleWeaponRestriction(i, weaponId, 1);
+	}
 }

--- a/codegen/rc4/survival/utils.h
+++ b/codegen/rc4/survival/utils.h
@@ -12,12 +12,13 @@
 extern struct SurvivalMapConfig MapConfig;
 extern struct SurvivalBakedConfig bakedConfig;
 
-void playPaidSound(Player* player);
-int tryPlayerInteract(Moby* moby, Player* player, char* message, char* lowerMessage, int boltCost, int tokenCost, int actionCooldown, float sqrDistance, int btns);
+void playPaidSound(Player *player);
+int tryPlayerInteract(Moby *moby, Player *player, char *message, char *lowerMessage, int boltCost, int tokenCost, int actionCooldown, float sqrDistance, int btns);
 
-int mobyIsMob(Moby* moby);
+int mobyIsMob(Moby *moby);
 int playerHasBlessing(int playerId, int blessing);
 int playerGetStackableCount(int playerId, int stackable);
+void playerTeleportToSpawn(Player *player, float dealtDamagePercentOfMaxHealth);
 int localPlayerHasInput(void);
 
 int bakedSpawnGetFirst(int bakedSpawnType, VECTOR outPos, VECTOR outRot);


### PR DESCRIPTION
Adds getters for baked config like `mapGetDifficultyMultiplier()`, enabling map makers to override said getters to implement their own custom behavior.