### PR TITLE
Survival: Fix prestige/upgrade costs

### DIFF
--- a/Assets/Forge/Scripts/CustomMode/SurvivalMobsScriptableObject.cs
+++ b/Assets/Forge/Scripts/CustomMode/SurvivalMobsScriptableObject.cs
@@ -22,7 +22,6 @@ public class SurvivalMobsScriptableObject : ScriptableObject
     public List<SurvivalWeaponStats> WeaponStats = new List<SurvivalWeaponStats>();
     public List<SpriteDef> SurvivalMysteryBoxSprites = new List<SpriteDef>();
     public List<SpriteDef> SurvivalStackableSprites = new List<SpriteDef>();
-    public List<SpriteDef> SurvivalBlessingSprites = new List<SpriteDef>();
     
     [Serializable]
     public class SurvivalMobsConfig

--- a/Assets/Forge/Scripts/CustomMode/SurvivalModeData.cs
+++ b/Assets/Forge/Scripts/CustomMode/SurvivalModeData.cs
@@ -16,7 +16,7 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
     public const int BANK_OCLASS = 0x1F7;
     public const int STACKBOX_OCLASS = 0x2083;
     public const int SURVIVAL_MAX_SPAWNED_MOBS = 50;
-    static readonly uint[] DEFAULT_PRESTIGE_COSTS = { 100000, 300000, 500000, 700000, 1000000 };
+    static readonly uint[] DEFAULT_PRESTIGE_COSTS = { 100000, 200000, 400000, 700000, 1000000 };
     static readonly uint[] DEFAULT_VENDOR_COSTS = { 8000, 12000, 20000, 40000, 60000, 90000, 150000, 220000, 350000 };
     static readonly string[] DEFAULT_ALPHA_MODS = { "SPEED", "AMMO", "IMPACT", "AREA", "JACKPOT", "XP" };
 	static readonly SurvivalStackableEntry[] DEFAULT_STACKABLE_ENTRIES = { 
@@ -101,8 +101,8 @@ public class SurvivalModeData : CustomModeData, ICodeGen, IBuildHook
     [Header("Wall Upgrades")]
     public List<SurvivalUpgradeEntry> Upgrades = new List<SurvivalUpgradeEntry>()
     {
-        new SurvivalUpgradeEntry() { Type = SurvivalUpgradeId.Health, Max = 2000 },
-        new SurvivalUpgradeEntry() { Type = SurvivalUpgradeId.Damage, Max = 2000 },
+        new SurvivalUpgradeEntry() { Type = SurvivalUpgradeId.Health, Max = 1000 },
+        new SurvivalUpgradeEntry() { Type = SurvivalUpgradeId.Damage, Max = 1000 },
         new SurvivalUpgradeEntry() { Type = SurvivalUpgradeId.Crit, Max = 100 },
         new SurvivalUpgradeEntry() { Type = SurvivalUpgradeId.Speed, Max = 40 },
     };

--- a/Assets/Forge/Scripts/Editor/CustomMode/SurvivalMobsScriptableObjectEditor.cs
+++ b/Assets/Forge/Scripts/Editor/CustomMode/SurvivalMobsScriptableObjectEditor.cs
@@ -15,7 +15,6 @@ public class SurvivalMobsScriptableObjectEditor : Editor
     private SerializedProperty m_WeaponStatsProperty;
     private SerializedProperty m_SurvivalMysteryBoxSprites;
     private SerializedProperty m_SurvivalStackableSprites;
-    private SerializedProperty m_SurvivalBlessingSprites;
 
     private void OnEnable()
     {
@@ -24,7 +23,6 @@ public class SurvivalMobsScriptableObjectEditor : Editor
         m_WeaponStatsProperty = serializedObject.FindProperty("WeaponStats");
         m_SurvivalMysteryBoxSprites = serializedObject.FindProperty("SurvivalMysteryBoxSprites");
         m_SurvivalStackableSprites = serializedObject.FindProperty("SurvivalStackableSprites");
-        m_SurvivalBlessingSprites = serializedObject.FindProperty("SurvivalBlessingSprites");
     }
 
 
@@ -66,7 +64,6 @@ public class SurvivalMobsScriptableObjectEditor : Editor
         EditorGUILayout.PropertyField(m_WeaponStatsProperty);
         EditorGUILayout.PropertyField(m_SurvivalMysteryBoxSprites);
         EditorGUILayout.PropertyField(m_SurvivalStackableSprites);
-        EditorGUILayout.PropertyField(m_SurvivalBlessingSprites);
         serializedObject.ApplyModifiedProperties();
     }
 

--- a/codegen/rc4/survival/interop.c
+++ b/codegen/rc4/survival/interop.c
@@ -152,9 +152,12 @@ int mapCanPrestigePlayerWeapon(Player *player, int gadgetId, int prestigeNum, ch
 }
 
 //--------------------------------------------------------------------------
-u32 mapGetPrestigePlayerWeaponCost(Player *player, int gadgetId, int levelNum)
+u32 mapGetPrestigePlayerWeaponCost(Player *player, int gadgetId, int prestigeNum)
 {
-	return bakedConfig.PrestigeCostPerLevel[levelNum];
+	if (prestigeNum <= 0)
+		return 0;
+
+	return bakedConfig.PrestigeCostPerLevel[prestigeNum - 1];
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
Fix defaults for upgrades and prestiging
Fix mapGetPrestigePlayerWeaponCost() returning wrong cost index Remove old blessings data