### PR TITLE
Enforce invariant culture sky.asset in sky2 folder | Consistent float precision in sky.asset (between sky-sky2)

### DIFF
--- a/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
+++ b/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
@@ -2,6 +2,7 @@ using GLTFast.Export;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -17,6 +18,15 @@ using UnityEngine.UIElements;
 
 public static class ForgeBuilder
 {
+    static ForgeBuilder()
+    {
+        var culture = CultureInfo.InvariantCulture;
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        Thread.CurrentThread.CurrentCulture = culture;
+        Thread.CurrentThread.CurrentUICulture = culture;
+    }
+
     static readonly (int RacVersion, GameRegion Region)[] BUILD_VERSIONS = new (int RacVersion, GameRegion Region)[]
     {
         (RCVER.DL, GameRegion.NTSC),
@@ -638,8 +648,8 @@ public static class ForgeBuilder
 
                     writer.WriteLine($"\t\tSkyShell {i} {{");
                     writer.WriteLine($"\t\t\tbloom: {(layer.Bloom ? "true" : "false")}");
-                    writer.WriteLine($"\t\t\tstarting_rotation: [{euler.y} {euler.x} {euler.z}]");
-                    writer.WriteLine($"\t\t\tangular_velocity: [{angvel.y} {angvel.x} {angvel.z}]");
+                    writer.WriteLine($"\t\t\tstarting_rotation: [{euler.y:G9} {euler.x:G9} {euler.z:G9}]");
+                    writer.WriteLine($"\t\t\tangular_velocity: [{angvel.y:G9} {angvel.x:G9} {angvel.z:G9}]");
                     writer.WriteLine($"");
                     writer.WriteLine("\t\t\tMesh mesh {");
                     writer.WriteLine($"\t\t\t\tname: \"{mesh.name}\"");

--- a/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
+++ b/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
@@ -18,15 +18,6 @@ using UnityEngine.UIElements;
 
 public static class ForgeBuilder
 {
-    static ForgeBuilder()
-    {
-        var culture = CultureInfo.InvariantCulture;
-        CultureInfo.DefaultThreadCurrentCulture = culture;
-        CultureInfo.DefaultThreadCurrentUICulture = culture;
-        Thread.CurrentThread.CurrentCulture = culture;
-        Thread.CurrentThread.CurrentUICulture = culture;
-    }
-
     static readonly (int RacVersion, GameRegion Region)[] BUILD_VERSIONS = new (int RacVersion, GameRegion Region)[]
     {
         (RCVER.DL, GameRegion.NTSC),
@@ -648,8 +639,8 @@ public static class ForgeBuilder
 
                     writer.WriteLine($"\t\tSkyShell {i} {{");
                     writer.WriteLine($"\t\t\tbloom: {(layer.Bloom ? "true" : "false")}");
-                    writer.WriteLine($"\t\t\tstarting_rotation: [{euler.y:G9} {euler.x:G9} {euler.z:G9}]");
-                    writer.WriteLine($"\t\t\tangular_velocity: [{angvel.y:G9} {angvel.x:G9} {angvel.z:G9}]");
+                    writer.WriteLine($"\t\t\tstarting_rotation: [{euler.y.ToInvariantCulture("G9")} {euler.x.ToInvariantCulture("G9")} {euler.z.ToInvariantCulture("G9")}]");
+                    writer.WriteLine($"\t\t\tangular_velocity: [{angvel.y.ToInvariantCulture("G9")} {angvel.x.ToInvariantCulture("G9")} {angvel.z.ToInvariantCulture("G9")}]");
                     writer.WriteLine($"");
                     writer.WriteLine("\t\t\tMesh mesh {");
                     writer.WriteLine($"\t\t\t\tname: \"{mesh.name}\"");

--- a/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
+++ b/Assets/Forge/Scripts/Editor/Builder/ForgeBuilder.cs
@@ -2,7 +2,6 @@ using GLTFast.Export;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;

--- a/Assets/Forge/Scripts/Helpers/StringHelper.cs
+++ b/Assets/Forge/Scripts/Helpers/StringHelper.cs
@@ -50,6 +50,7 @@ public static class StringHelper
     }
 
     public static string ToInvariantCulture(this float value) => value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    public static string ToInvariantCulture(this float value, string format) => value.ToString(format, System.Globalization.CultureInfo.InvariantCulture);
     public static string ToInvariantCulture(this double value) => value.ToString(System.Globalization.CultureInfo.InvariantCulture);
     public static string ToInvariantCulture(this decimal value) => value.ToString(System.Globalization.CultureInfo.InvariantCulture);
 }


### PR DESCRIPTION
PR that:
- Enforces invariant culture for sky.asset generated by ForgeBuilder.cs (in sky2 folder) to ensure decimals always use '.' instead of ',' across different systems and localizations
- Uses G9 formatting for floats to match Wrench float precision for sky.asset files in sky and sky2 folders