### PR TITLE
CodeGen: Update COLLISION_FLAG values to use new names

### DIFF
--- a/codegen/rc4/common/maputils.c
+++ b/codegen/rc4/common/maputils.c
@@ -99,7 +99,7 @@ void damageRadius(Moby* moby, VECTOR position, u32 damageFlags, float damage, fl
   in.Flags = 1;
   in.DamageHp = damage;
 
-  CollMobysSphere_Fix(position, COLLISION_FLAG_IGNORE_STATIC, moby, &in, damageRadius);
+  CollMobysSphere_Fix(position, COLLISION_FLAG_IGNORE_NONDAMAGEABLE, moby, &in, damageRadius);
 }
 
 //--------------------------------------------------------------------------

--- a/codegen/rc4/raids/ammodrop.c
+++ b/codegen/rc4/raids/ammodrop.c
@@ -90,7 +90,7 @@ void ammodropCreateAt(Moby* moby)
     vector_copy(ammoMoby->Position, moby->Position);
     vector_add(from, moby->Position, from);
     vector_add(to, moby->Position, to);
-    if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+    if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
       vector_copy(ammoMoby->Position, CollLine_Fix_GetHitPosition());
     }
 

--- a/codegen/rc4/raids/drop.c
+++ b/codegen/rc4/raids/drop.c
@@ -153,7 +153,7 @@ void dropUpdate(Moby* moby)
   if (!pvars->HitGround) {
     vector_add(t, moby->Position, down);
     vector_subtract(t, t, offset);
-    if (CollLine_Fix(moby->Position, t, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+    if (CollLine_Fix(moby->Position, t, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
       pvars->HitGround = 1;
     } else {
       vector_add(moby->Position, t, offset);

--- a/codegen/rc4/raids/maputils.c
+++ b/codegen/rc4/raids/maputils.c
@@ -106,7 +106,7 @@ void damageRadius(Moby* moby, VECTOR position, u32 damageFlags, float damage, fl
   in.Flags = 1;
   in.DamageHp = damage;
 
-  CollMobysSphere_Fix(position, COLLISION_FLAG_IGNORE_STATIC, moby, &in, damageRadius);
+  CollMobysSphere_Fix(position, COLLISION_FLAG_IGNORE_NONDAMAGEABLE, moby, &in, damageRadius);
 }
 
 //--------------------------------------------------------------------------

--- a/codegen/rc4/raids/mobs/mob.c
+++ b/codegen/rc4/raids/mobs/mob.c
@@ -587,11 +587,11 @@ int mobMoveCheck(Moby* moby, VECTOR outputPos, VECTOR from, VECTOR to)
   // get if we should check for collisions with all colliders
   // we have to alternate because when many mobs are in one space
   // collision checks against all of them become extremely expensive
-  int collFlag = (mobMoveCheckCollideWithOtherMobsRotatingIndex == pvars->MobVars.Order) ? COLLISION_FLAG_IGNORE_NONE : COLLISION_FLAG_IGNORE_DYNAMIC;
+  int collFlag = (mobMoveCheckCollideWithOtherMobsRotatingIndex == pvars->MobVars.Order) ? COLLISION_FLAG_IGNORE_NONE : COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS;
 
   // if we're stuck, ignore other mobs and just try and get unstuck
   if (pvars->MobVars.MoveVars.IsStuck)
-    collFlag = COLLISION_FLAG_IGNORE_DYNAMIC;
+    collFlag = COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS;
 
   // move up by collradius
   up[2] = collRadius; // 0.5;
@@ -731,7 +731,7 @@ void mobMove(Moby* moby)
     vector_subtract(delta, pvars->MobVars.MoveVars.Target->Position, moby->Position);
     vector_add(from, moby->Position, up);
     vector_add(to, pvars->MobVars.MoveVars.Target->Position, up);
-    if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+    if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
       vector_copy(MoveTargetLineOfSightHit, CollLine_Fix_GetHitPosition());
     } else {
       vector_copy(MoveTargetLineOfSightHit, to);
@@ -814,7 +814,7 @@ void mobMove(Moby* moby)
       groundCheckFrom[2] = maxf(moby->Position[2], ledgePos[2]) + ZOMBIE_BASE_STEP_HEIGHT;
       vector_copy(groundCheckTo, ledgePos);
       groundCheckTo[2] = gameGetDeathHeight();
-      if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+      if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
         currentHeightFromGround = pvars->MobVars.MoveVars.DistFromGround = vector_distance(moby->Position, CollLine_Fix_GetHitPosition());
       } else {
         // no ground
@@ -836,7 +836,7 @@ void mobMove(Moby* moby)
         groundCheckFrom[2] = maxf(moby->Position[2], ledgePos[2]) + ZOMBIE_BASE_STEP_HEIGHT;
         vector_copy(groundCheckTo, ledgePos);
         groundCheckTo[2] = gameGetDeathHeight();
-        if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+        if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
           currentHeightFromGround = pvars->MobVars.MoveVars.DistFromGround = vector_distance(moby->Position, CollLine_Fix_GetHitPosition());
           if (!mobCollisionIdIsWalkable(CollLine_Fix_GetHitCollisionId()) || mobCollisionIdIsLethal(CollLine_Fix_GetHitCollisionId())) {
             nextPosHasSafeGround = 0;
@@ -854,7 +854,7 @@ void mobMove(Moby* moby)
         groundCheckFrom[2] = maxf(moby->Position[2], nextPos[2]) + ZOMBIE_BASE_STEP_HEIGHT;
         vector_copy(groundCheckTo, nextPos);
         groundCheckTo[2] -= 0.5;
-        if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+        if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
 
           // mark grounded this frame
           pvars->MobVars.MoveVars.Grounded = 1;
@@ -887,7 +887,7 @@ void mobMove(Moby* moby)
         vector_copy(groundCheckTo, nextPos);
         groundCheckTo[2] += 3;
         //groundCheckTo[2] += ZOMBIE_BASE_STEP_HEIGHT;
-        if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+        if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
           // force position to below ceiling
           //vector_copy(nextPos, CollLine_Fix_GetHitPosition());
           //nextPos[2] -= 0.01;
@@ -1358,7 +1358,7 @@ int mobCanSeeMoby(Moby* moby, Moby* canSeeMoby)
       vector_add(t, moby->Position, up);
     }
 
-    return !CollLine_Fix(t, t2, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL) || CollLine_Fix_GetHitMoby() == canSeeMoby;
+    return !CollLine_Fix(t, t2, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL) || CollLine_Fix_GetHitMoby() == canSeeMoby;
   }
   
   return 0;

--- a/codegen/rc4/raids/pathfind.c
+++ b/codegen/rc4/raids/pathfind.c
@@ -280,7 +280,7 @@ int pathGetClosestNodeInSight(struct PathGraph* path, Moby* moby, int * foundInS
     float dist = nodeDists[i] = maxf(0, vector_length(delta) - radius);
 
     // if obstructed then increase distance by factor
-    //if (CollLine_Fix(position, path->Nodes[i], COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL))
+    //if (CollLine_Fix(position, path->Nodes[i], COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL))
     //  dist *= 1000;
     
     for (j = 0; j < CLOSEST_NODES_COLL_CHECK_SIZE; ++j) {
@@ -316,7 +316,7 @@ int pathGetClosestNodeInSight(struct PathGraph* path, Moby* moby, int * foundInS
       vector_subtract(nodePos, nodePos, delta);
 
       // check if closest point is obstructed
-      if (orderedNodesByDist[i] >= 0 && !CollLine_Fix(position, nodePos, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+      if (orderedNodesByDist[i] >= 0 && !CollLine_Fix(position, nodePos, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
         if (foundInSight)
           *foundInSight = 1;
 
@@ -768,7 +768,7 @@ int pathGetTargetPos(struct PathGraph* path, VECTOR output, Moby* moby, struct M
     vector_add(to, moveVars->TargetPosition, up);
 
     // near and can see
-    if (vector_sqrmag(delta) < (MOB_TARGET_DIST_IN_SIGHT_IGNORE_PATH*MOB_TARGET_DIST_IN_SIGHT_IGNORE_PATH) && !CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+    if (vector_sqrmag(delta) < (MOB_TARGET_DIST_IN_SIGHT_IGNORE_PATH*MOB_TARGET_DIST_IN_SIGHT_IGNORE_PATH) && !CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
 
       // not in opposite direction of current edge
       u8* currentEdge = pathGetCurrentEdge(path, moby, moveVars);
@@ -846,7 +846,7 @@ int pathGetTargetPos(struct PathGraph* path, VECTOR output, Moby* moby, struct M
         VECTOR from, to;
         vector_add(from, up, moby->Position);
         vector_add(to, up, path->Nodes[lastEdge[1]]);
-        if (!CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+        if (!CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
           moveVars->PathHasReachedEnd = 1;
         }
       }

--- a/codegen/rc4/raids/spawner.c
+++ b/codegen/rc4/raids/spawner.c
@@ -948,7 +948,7 @@ void spawnerStart(void)
     VECTOR spawnFrom, spawnTo, up={0,0,0.1,0}, down = {0,0,-30,0};
     vector_add(spawnFrom, request->SpawnArgs.Position, up);
     vector_add(spawnTo, request->SpawnArgs.Position, down);
-    if (!CollLine_Fix(spawnFrom, spawnTo, COLLISION_FLAG_IGNORE_DYNAMIC, NULL, NULL)) {
+    if (!CollLine_Fix(spawnFrom, spawnTo, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, NULL, NULL)) {
       memcpy(&deferredRequests[deferredRequestsCount], request, sizeof(struct SpawnerSpawnRequest));
       deferredRequestsCount++;
       DLOG(request->Spawner, "spawn %d failed, could not find any ground (pos:(%.2f,%.2f,%.2f))\n"

--- a/codegen/rc4/survival/mobs/mob.c
+++ b/codegen/rc4/survival/mobs/mob.c
@@ -339,7 +339,7 @@ int mobCanSeeMoby(Moby *moby, Moby *canSeeMoby)
 		vector_add(t, moby->Position, up);
 		//}
 
-		return !CollLine_Fix(t, t2, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL) || CollLine_Fix_GetHitMoby() == canSeeMoby;
+		return !CollLine_Fix(t, t2, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL) || CollLine_Fix_GetHitMoby() == canSeeMoby;
 	}
 
 	return 0;
@@ -921,11 +921,11 @@ int mobMoveCheck(Moby *moby, VECTOR outputPos, VECTOR from, VECTOR to)
 	// get if we should check for collisions with all colliders
 	// we have to alternate because when many mobs are in one space
 	// collision checks against all of them become extremely expensive
-	int collFlag = (mobMoveCheckCollideWithOtherMobsRotatingIndex == pvars->MobVars.Order) ? COLLISION_FLAG_IGNORE_NONE : COLLISION_FLAG_IGNORE_DYNAMIC;
+	int collFlag = (mobMoveCheckCollideWithOtherMobsRotatingIndex == pvars->MobVars.Order) ? COLLISION_FLAG_IGNORE_NONE : COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS;
 
 	// if we're stuck, ignore other mobs and just try and get unstuck
 	if (pvars->MobVars.MoveVars.IsStuck)
-		collFlag = COLLISION_FLAG_IGNORE_DYNAMIC;
+		collFlag = COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS;
 
 	// move up by collradius
 	up[2] = collRadius; // 0.5;
@@ -1081,7 +1081,7 @@ void mobMove(Moby *moby)
 		vector_subtract(delta, pvars->MobVars.Target->Position, moby->Position);
 		vector_add(from, moby->Position, up);
 		vector_add(to, pvars->MobVars.Target->Position, up);
-		if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL))
+		if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL))
 		{
 			vector_copy(MoveTargetLineOfSightHit, CollLine_Fix_GetHitPosition());
 		}
@@ -1165,7 +1165,7 @@ void mobMove(Moby *moby)
 				groundCheckFrom[2] = maxf(moby->Position[2], nextPos[2]) + ZOMBIE_BASE_STEP_HEIGHT;
 				vector_copy(groundCheckTo, nextPos);
 				groundCheckTo[2] -= 0.5;
-				if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL))
+				if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL))
 				{
 					// mark grounded this frame
 					pvars->MobVars.MoveVars.Grounded = 1;
@@ -1199,7 +1199,7 @@ void mobMove(Moby *moby)
 				vector_copy(groundCheckTo, nextPos);
 				groundCheckTo[2] += MOB_CEILING_CHECK_HEIGHT;
 				// groundCheckTo[2] += ZOMBIE_BASE_STEP_HEIGHT;
-				if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL))
+				if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL))
 				{
 					// force position to below ceiling
 					// vector_copy(nextPos, CollLine_Fix_GetHitPosition());

--- a/codegen/rc4/survival/mobs/reactor.c
+++ b/codegen/rc4/survival/mobs/reactor.c
@@ -576,7 +576,7 @@ int reactorGetPreferredState(Moby *moby, int *delayTicks)
 
 			vector_add(mobyPosUp, moby->Position, up);
 			vector_add(targetPosUp, target->Position, up);
-			int targetInSight = !CollLine_Fix(mobyPosUp, targetPosUp, COLLISION_FLAG_IGNORE_DYNAMIC, NULL, NULL);
+			int targetInSight = !CollLine_Fix(mobyPosUp, targetPosUp, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, NULL, NULL);
 			if (!targetInSight)
 			{
 				return REACTOR_STATE_WALK;
@@ -1500,7 +1500,7 @@ void reactorSpawnMinion(Moby *moby, float radius)
 		vector_subtract(to, from, hitOffset);
 		vector_add(from, from, hitOffset);
 
-		if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL))
+		if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL))
 		{
 			vector_copy(position, CollLine_Fix_GetHitPosition());
 			break;

--- a/codegen/rc4/survival/mobs/tremor.c
+++ b/codegen/rc4/survival/mobs/tremor.c
@@ -693,7 +693,7 @@ void tremorSpawnQuake(Moby *moby, float speed, int jointIdx)
 	VECTOR groundCheckTo = {0, 0, 0, 0};
 	vector_add(groundCheckFrom, groundCheckFrom, spawnAt);
 	vector_add(groundCheckTo, groundCheckTo, spawnAt);
-	if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL))
+	if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL))
 		vector_add(spawnAt, CollLine_Fix_GetHitPosition(), (VECTOR){0, 0, 0.1, 0});
 
 	// spawn quake moby

--- a/codegen/rc4/survival/mobs/zombie.c
+++ b/codegen/rc4/survival/mobs/zombie.c
@@ -743,7 +743,7 @@ void zombieThrowMobyUpdate(Moby *moby)
 
 	// check for collision
 	// if hit anything, destroy
-	if (CollLine_Fix(startHeadPos, nextHeadPos, COLLISION_FLAG_IGNORE_DYNAMIC, pvars->ThrownBy, NULL))
+	if (CollLine_Fix(startHeadPos, nextHeadPos, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, pvars->ThrownBy, NULL))
 	{
 		vector_copy(pvars->HeadPos, CollLine_Fix_GetHitPosition());
 		zombieThrowMobySpawnExplosion(moby);
@@ -903,7 +903,7 @@ void zombieSpawnThrowMoby(Moby *moby, float speed, int jointIdx)
 	VECTOR groundCheckTo = {0, 0, 0, 0};
 	vector_add(groundCheckFrom, groundCheckFrom, spawnAt);
 	vector_add(groundCheckTo, groundCheckTo, spawnAt);
-	if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL))
+	if (CollLine_Fix(groundCheckFrom, groundCheckTo, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL))
 		vector_add(spawnAt, CollLine_Fix_GetHitPosition(), (VECTOR){0, 0, 0.1, 0});
 
 	// spawn throw moby

--- a/codegen/rc4/survival/mobys/ammodrop.c
+++ b/codegen/rc4/survival/mobys/ammodrop.c
@@ -113,7 +113,7 @@ void ammodropCreateAt(Moby *moby)
 		vector_copy(ammoMoby->Position, moby->Position);
 		vector_add(from, moby->Position, from);
 		vector_add(to, moby->Position, to);
-		if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL))
+		if (CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL))
 		{
 			vector_copy(ammoMoby->Position, CollLine_Fix_GetHitPosition());
 		}

--- a/codegen/rc4/survival/mobys/drop.c
+++ b/codegen/rc4/survival/mobys/drop.c
@@ -243,7 +243,7 @@ void dropUpdate(Moby *moby)
 	{
 		vector_add(t, moby->Position, down);
 		vector_subtract(t, t, offset);
-		if (CollLine_Fix(moby->Position, t, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL))
+		if (CollLine_Fix(moby->Position, t, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL))
 		{
 			pvars->HitGround = 1;
 		}

--- a/codegen/rc4/survival/pathfind.c
+++ b/codegen/rc4/survival/pathfind.c
@@ -306,7 +306,7 @@ int pathGetClosestNodeInSight(Moby* moby, int * foundInSight)
     float dist = nodeDists[i] = maxf(0, vector_length(delta) - radius);
 
     // if obstructed then increase distance by factor
-    //if (CollLine_Fix(position, MOB_PATHFINDING_NODES[i], COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL))
+    //if (CollLine_Fix(position, MOB_PATHFINDING_NODES[i], COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL))
     //  dist *= 1000;
     
     for (j = 0; j < CLOSEST_NODES_COLL_CHECK_SIZE; ++j) {
@@ -342,7 +342,7 @@ int pathGetClosestNodeInSight(Moby* moby, int * foundInSight)
       vector_subtract(nodePos, nodePos, delta);
 
       // check if closest point is obstructed
-      if (orderedNodesByDist[i] >= 0 && !CollLine_Fix(position, nodePos, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+      if (orderedNodesByDist[i] >= 0 && !CollLine_Fix(position, nodePos, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
         if (foundInSight)
           *foundInSight = 1;
 
@@ -730,7 +730,7 @@ int pathGetTargetPos(VECTOR output, Moby* moby)
     vector_add(to, pvars->MobVars.TargetPosition, up);
 
     // near and can see
-    if (vector_sqrmag(delta) < (MOB_TARGET_DIST_IN_SIGHT_IGNORE_PATH*MOB_TARGET_DIST_IN_SIGHT_IGNORE_PATH) && !CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+    if (vector_sqrmag(delta) < (MOB_TARGET_DIST_IN_SIGHT_IGNORE_PATH*MOB_TARGET_DIST_IN_SIGHT_IGNORE_PATH) && !CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
 
       // not in opposite direction of current edge
       u8* currentEdge = pathGetCurrentEdge(moby);
@@ -798,7 +798,7 @@ int pathGetTargetPos(VECTOR output, Moby* moby)
         VECTOR from, to;
         vector_add(from, up, moby->Position);
         vector_add(to, up, MOB_PATHFINDING_NODES[lastEdge[1]]);
-        if (!CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_DYNAMIC, moby, NULL)) {
+        if (!CollLine_Fix(from, to, COLLISION_FLAG_IGNORE_MOBY_SPECIAL_COLLIDERS, moby, NULL)) {
           pvars->MobVars.MoveVars.PathHasReachedEnd = 1;
         }
       }


### PR DESCRIPTION
[latest libdl commit](https://github.com/Dnawrkshp/libdl/commit/f2fcef0933004b51a9ec1d04a73291f4adf5e442) renames some enum values. This commit updates usage of the old names to the new.